### PR TITLE
Feat: 사용자 관련 엔티티 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.metadata/

--- a/costcook/src/main/java/com/costcook/CostcookApplication.java
+++ b/costcook/src/main/java/com/costcook/CostcookApplication.java
@@ -2,8 +2,10 @@ package com.costcook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CostcookApplication {
 
 	public static void main(String[] args) {

--- a/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
+++ b/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
@@ -1,0 +1,6 @@
+package com.costcook.domain;
+
+public enum PlatformTypeEnum {
+    KAKAO,
+    GOOGLE
+}

--- a/costcook/src/main/java/com/costcook/domain/RoleEnum.java
+++ b/costcook/src/main/java/com/costcook/domain/RoleEnum.java
@@ -1,0 +1,18 @@
+package com.costcook.domain;
+
+public enum RoleEnum {
+	ROLE_USER("ROLE_USER"),
+	ROLE_ADMIN("ROLE_ADMIN");
+	
+	String role;
+	
+    // 생성자
+	RoleEnum(String role) {
+		this.role = role;
+	}
+	
+    // Getter
+	public String getRole() {
+		return role;
+	}
+}

--- a/costcook/src/main/java/com/costcook/domain/StatusEnum.java
+++ b/costcook/src/main/java/com/costcook/domain/StatusEnum.java
@@ -1,0 +1,25 @@
+package com.costcook.domain;
+
+public enum StatusEnum {
+    INACTIVE(0), // 비활성화 상태
+    ACTIVE(1); // 활성화 상태
+
+    private final int value;
+
+    StatusEnum(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static StatusEnum fromValue(int value) {
+        for (StatusEnum status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("유효하지 않은 값입니다: " + value);
+    }
+}

--- a/costcook/src/main/java/com/costcook/entity/Recipe.java
+++ b/costcook/src/main/java/com/costcook/entity/Recipe.java
@@ -12,8 +12,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/costcook/src/main/java/com/costcook/entity/SocialAccount.java
+++ b/costcook/src/main/java/com/costcook/entity/SocialAccount.java
@@ -1,0 +1,35 @@
+package com.costcook.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import com.costcook.domain.PlatformTypeEnum;
+
+@Entity
+@Table(name = "social_accounts")
+@Data
+@NoArgsConstructor
+public class SocialAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 식별자
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 사용자 (외래 키)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform_type")
+    private PlatformTypeEnum platformType; // 플랫폼 타입 (KAKAO, GOOGLE)
+
+    @Column(name = "social_key", length = 255)
+    private String socialKey; // 소셜 키
+
+    @CreatedDate
+    @Column(name = "connected_at", nullable = false)
+    private LocalDateTime connectedAt; // 연결된 시간
+}

--- a/costcook/src/main/java/com/costcook/entity/User.java
+++ b/costcook/src/main/java/com/costcook/entity/User.java
@@ -1,0 +1,86 @@
+package com.costcook.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.costcook.domain.RoleEnum;
+import com.costcook.domain.StatusEnum;
+
+@Entity
+@Table(name = "users")
+@EntityListeners(AuditingEntityListener.class) // 생성, 수정 날짜 추적 -> Application.java (@EnableJpaAuditing)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false) // 이 필드 값은 생성할 때만 값 설정 가능.
+    private Long id;
+
+    @Column(length = 255, unique = true) // 해당 컬럼이 유일해야 한다는 제약 조건을 설정
+    private String email;
+
+    @Column(length = 100, nullable = true) // 선택 입력 정보
+    private String nickname;
+
+    @Column(length = 255, nullable = true)  // 선택 입력 정보
+    private String profileUrl;
+
+    @Column(name = "service_agreement")
+    private Boolean serviceAgreement;
+
+    @Column(name = "privacy_policy_agreement")
+    private Boolean privacyPolicyAgreement;
+
+    @Column(name = "additional_info_agreement")
+    private Boolean additionalInfoAgreement;
+
+    @Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	@Builder.Default
+	private RoleEnum role = RoleEnum.ROLE_USER; // 권한 컬럼 추가 (기본값 ROLE_USER)
+
+    @Column(name = "warning_count")
+    private Integer warningCount;
+
+    @Column(name = "refresh_token", length = 255)
+    private String refreshToken; // 리프레시 토큰
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false) // 이 필드 값은 생성할 때만 값 설정 가능.
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "status")
+    private StatusEnum status = StatusEnum.ACTIVE; // 기본값을 ACTIVE로 설정, TINYINT로 매핑됨
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }    
+
+    // @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    // private List<SocialAccount> socialAccounts; // 소셜 계정 리스트
+}

--- a/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
@@ -1,8 +1,12 @@
 package com.costcook.service.impl;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.costcook.domain.response.RecipeResponse;
 import com.costcook.repository.RecipeRepository;
+import com.costcook.service.RecipeService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,9 +14,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RecipeServiceImpl {
+public class RecipeServiceImpl implements RecipeService {
 	
 	private final RecipeRepository recipeRepository;
+
+	@Override
+	public List<RecipeResponse> getAllRecipe() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public RecipeResponse getRecipeById(Long id) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 	
 
 }


### PR DESCRIPTION
## 작업 내용 (What)
User 엔티티 구현
SocialAccount 엔티티 구현
User 엔티티 필드 중 role, status 는 각각 Enum 으로 구현(RoleEnum, StatusEnum)
User 엔티티와 SocialAccount 엔티티 1대 다 관계 설정. (현재: 양방향으로 맺어져 있으나 이후 단방향으로 변경할까 고민중)
설계상 변경으로 refreshToken 필드는 SocialAccount 엔티티에서 User 엔티티로 이동.
프로필 이미지는 ImageFile 엔티티를 구현하는 대신 profileUrl 필드를 User 엔티티에 추가하는 것으로 대신.

## 작업 이유 (Why)
User 엔티티 및 SocialAccount 엔티티는 사용자 정보를 저장하기 위해 필요.

## 변경 사항 (Changes)
코드 변경 사항에 대해 구체적으로 설명합니다.

- [x] User 엔티티 구현
- [x] SocialAccount 엔티티 구현
- [x] RoleEnum 구현
- [x] StatusEnum 구현
- [x] User 엔티티에 profileUrl 필드 추가.
- [x] User 엔티티에 refreshToken 필드 추가.

## 추가로 논의할 부분
현재 Usesr 엔티티와 SocialAccount 엔티티는 1대 다 관계로 설정했으며, 양방향으로 관계가 맺어져 있다.
양방향으로 관계를 맺을 시 복잡도가 증가하기 때문에 추후 구현 방식에 따라 단방향으로 관계가 맺어지는 방향으로 변경될 가능성이 높다. 
