### PR TITLE
Feat: 인증 코드 확인 기능 구현

### DIFF
--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.costcook.controller;
 
+import java.util.Map;
 import java.util.Random;
 
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.costcook.domain.request.EmailRequest;
+import com.costcook.domain.request.VerificationRequest;
 import com.costcook.service.EmailService;
 import com.costcook.util.EmailUtil;
 
@@ -42,6 +44,31 @@ public class AuthController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                                  .body("이메일 전송에 실패했습니다. 다시 시도해주세요.");
+        }
+    }
+    
+    @PostMapping("/verify-code")
+    public ResponseEntity<?> verifyCode(@RequestBody VerificationRequest request) {
+        try {
+            boolean isVerified = emailService.verifyCode(request.getEmail(), request.getVerificationCode());
+
+            if (isVerified) {
+                return ResponseEntity.ok().body(Map.of(
+                        "isVerified", true,
+                        "message", "인증번호가 일치합니다."
+                ));
+            } else {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "isVerified", false,
+                        "message", "인증번호가 일치하지 않습니다."
+                ));
+            }
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", "인증 코드가 만료되었습니다. 다시 인증해주세요."));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러가 발생했습니다.");
         }
     }
 }

--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.costcook.domain.request.EmailRequest;
 import com.costcook.domain.request.VerificationRequest;
+import com.costcook.domain.response.VerifyCodeResponse;
 import com.costcook.service.EmailService;
 import com.costcook.util.EmailUtil;
 
@@ -51,9 +52,9 @@ public class AuthController {
 		boolean isVerified = emailService.verifyCode(request.getEmail(), request.getVerificationCode());
 
 		if (isVerified) {
-			return ResponseEntity.ok().body(Map.of("isVerified", true, "message", "인증번호가 일치합니다."));
+			 return ResponseEntity.ok(new VerifyCodeResponse(true, "인증번호가 일치합니다."));
 		} else {
-			throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+			 return ResponseEntity.ok(new VerifyCodeResponse(false, "인증번호가 일치하지 않습니다."));
 		}
 
 	}

--- a/costcook/src/main/java/com/costcook/domain/request/VerificationRequest.java
+++ b/costcook/src/main/java/com/costcook/domain/request/VerificationRequest.java
@@ -1,0 +1,9 @@
+package com.costcook.domain.request;
+
+import lombok.Data;
+
+@Data
+public class VerificationRequest {
+    private String email;
+    private String verificationCode;
+}

--- a/costcook/src/main/java/com/costcook/domain/response/VerifyCodeResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/VerifyCodeResponse.java
@@ -1,0 +1,11 @@
+package com.costcook.domain.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VerifyCodeResponse {
+    private boolean isVerified;
+    private String message;
+}

--- a/costcook/src/main/java/com/costcook/exceptions/ErrorResponse.java
+++ b/costcook/src/main/java/com/costcook/exceptions/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.costcook.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message; // 에러 메시지
+}

--- a/costcook/src/main/java/com/costcook/exceptions/GlobalExceptionHandler.java
+++ b/costcook/src/main/java/com/costcook/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.costcook.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+    
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
+        ErrorResponse errorResponse = new ErrorResponse("서버 에러가 발생했습니다.");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/costcook/src/main/java/com/costcook/repository/EmailVerificationRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/EmailVerificationRepository.java
@@ -1,8 +1,12 @@
 package com.costcook.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.costcook.entity.EmailVerification;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+	Optional<EmailVerification> findByUserEmail(String email);
+	Optional<EmailVerification> findTopByUserEmailOrderByCreatedAtDesc(String userEmail);
 }

--- a/costcook/src/main/java/com/costcook/service/EmailService.java
+++ b/costcook/src/main/java/com/costcook/service/EmailService.java
@@ -2,4 +2,5 @@ package com.costcook.service;
 
 public interface EmailService {
 	public void sendVerificationCode(String email, String verificationCode);
+	public boolean verifyCode(String email, String verificationCode);
 }

--- a/costcook/src/main/java/com/costcook/service/impl/EmailServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/EmailServiceImpl.java
@@ -7,9 +7,14 @@ import com.costcook.entity.EmailVerification;
 import com.costcook.repository.EmailVerificationRepository;
 import com.costcook.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
@@ -37,5 +42,21 @@ public class EmailServiceImpl implements EmailService {
 
 		emailVerificationRepository.save(emailVerification);
 	}
+	
+	public boolean verifyCode(String email, String verificationCode) {
+		log.info("verifyCode 메소드 실행 시작");
+        EmailVerification verification = emailVerificationRepository.findTopByUserEmailOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new IllegalArgumentException("이메일을 찾을 수 없습니다."));
+        log.info("verification 정보: {}", verification.toString());
+        
+        // 인증 코드 만료 확인
+        if (verification.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalStateException("인증 코드가 만료되었습니다.");
+        }
+
+        // 인증 코드 일치 여부 확인
+        log.info("인증 코드 일치여부 확인: {}", verification.getVerificationCode().equals(verificationCode));
+        return verification.getVerificationCode().equals(verificationCode);
+    }
 
 }


### PR DESCRIPTION
## 작업 내용 (What)
- 인증 코드 확인 기능 구현

## 작업 이유 (Why)
- 새로운 기능 추가

## 변경 사항 (Changes)
- [x] 인증 코드 확인 비즈니스 로직 구현
- [x] 인증 코드 검증 엔드포인트 추가(GET /api/auth/verify-code) 및 Request DTO 생성
- [x] ErrorResponse 를 통한 전역 예외 처리 구현 및 적용
- [x] verifyCode 메서드에 대한 응답 DTO 생성 및 적용

## 테스트 결과 (Test Result)
기능 테스트 결과는 아래와 같습니다.

- 인증 코드 검증 대상 데이터(사진 속 id: 3 데이터)
![verify_code_success](https://github.com/user-attachments/assets/c203566a-0c84-44f7-8930-768014d9d7ab)

- 성공 케이스:
![verify_code_success](https://github.com/user-attachments/assets/4e776fe2-9f5a-4abd-9766-f96e56d0ca09)

- 실패 케이스:
![verify_code_error](https://github.com/user-attachments/assets/ab98d50c-9fc9-4a20-9148-b86766d5d725)

## API 명세 정보
- https://www.notion.so/1184b7e536fc808e9413e870dccec216?pvs=4