### PR TITLE
feat: [feat/getRecipesWithPagination생성] 레시피 페이지 목록 조회(조회수, 평점 정렬), 페이지네이션

### DIFF
--- a/costcook/src/main/java/com/costcook/config/WebMvcConfig.java
+++ b/costcook/src/main/java/com/costcook/config/WebMvcConfig.java
@@ -1,0 +1,36 @@
+package com.costcook.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	// application.yml의 location 정보 가져오기
+	@Value("${spring.upload.location}")
+	private String uploadPath;
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+			.addMapping("/**")
+			.allowedOrigins("http://localhost:3000", "http://172.30.1.40:3000")
+			.allowedMethods("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE");
+	}
+	
+	// 웹 페이지에서 이미지 보여주기
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry
+			.addResourceHandler("/img/**")
+			.addResourceLocations("file:" + uploadPath + "\\");
+	}
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/controller/RecipeController.java
+++ b/costcook/src/main/java/com/costcook/controller/RecipeController.java
@@ -1,45 +1,134 @@
 package com.costcook.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.costcook.domain.request.RecipeRequest;
 import com.costcook.domain.response.RecipeResponse;
+import com.costcook.entity.Recipe;
+import com.costcook.service.ImageFileService;
 import com.costcook.service.RecipeService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/recipies")
+@RequestMapping("/api/recipes")
 public class RecipeController {
 	
 	private final RecipeService recipeService;
+	// application.yml의 location 정보 가져오기
+	@Value("${spring.upload.location}")
+	private String uploadPath;
 	
-	
-	// 레시피 전체 목록 조회
-	@GetMapping("")
-	public ResponseEntity<List<RecipeResponse>> getAllRecipe(@RequestParam(name = "id", required = false) Long id) {
-		List<RecipeResponse> result = new ArrayList<>();
-		// 레시피 ID가 없으면 모든 레시피 조회, 있으면 리스트에 추가
-		if (id == null) {
-			result = recipeService.getAllRecipe();
-		} else {
-			RecipeResponse RecipeResponse = recipeService.getRecipeById(id);
-			result.add(RecipeResponse);
-		}
-		return ResponseEntity.ok(result);
+	// 레시피 등록
+	@PostMapping("")
+	public ResponseEntity<RecipeResponse> addProduct(RecipeRequest recipeRequest, @RequestParam(name = "image", required = false) MultipartFile file) {
+
+//		// 토큰을 통해 로그인 유저 정보를 가져옴
+//		User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+//		RecipeResponse savedRecipe = recipeService.insertRecipe(recipeRequest, file, user);
+		RecipeResponse savedRecipe = recipeService.insertRecipe(recipeRequest, file);
+		
+		return ResponseEntity.status(HttpStatus.CREATED).body(savedRecipe);
 	}
 	
 	
+	// 레시피 전체 목록 조회 (페이지네이션)
+	@GetMapping(value = {"", "/"})
+	public ResponseEntity<Page<RecipeResponse>> getAllRecipe(
+			@RequestParam(name = "id", required = false) Long id,
+			@RequestParam(name = "page", defaultValue = "0") int page, 
+			@RequestParam(name = "size", defaultValue = "9") int size, 
+			@RequestParam(name = "sort", defaultValue = "createdAt") String sort,
+			@RequestParam(name = "order", defaultValue = "desc") String order
+			) {
+		
+		// 정렬 방향
+		Sort.Direction direction = order.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+		// 정렬 기준
+//		Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort));
+		Pageable pageable;
+		// 정렬 기준에 따른 Pageable 생성
+		if (sort.equals("avgRatings")) {
+			pageable = PageRequest.of(page, size, Sort.by(direction, "avgRatings")); 
+		} else if (sort.equals("viewCount")) {
+			pageable = PageRequest.of(page, size, Sort.by(direction, "viewCount"));
+		} else { // 기본 정렬
+			pageable = PageRequest.of(page, size, Sort.by(direction, sort));
+		}
+			
+		// 레시피 목록 가져오기
+		Page<RecipeResponse> recipes = recipeService.getAllRecipes(pageable, id);
+		
+		return ResponseEntity.ok(recipes);
+	}
+	
+	
+	// 레시피 상세보기
+	@GetMapping("/{id}")
+	public ResponseEntity<RecipeResponse> getRecipe(@PathVariable("id") Long id) {
+		RecipeResponse recipeResponse = recipeService.getRecipeById(id);
+		return ResponseEntity.ok(recipeResponse);
+	}
+	
+	
+	// 레시피 수정
+	@PatchMapping("")
+	public ResponseEntity<RecipeResponse> modifyRecipe(RecipeRequest recipeRequest, @RequestParam(name = "image", required = false) MultipartFile file) {
+//		// 토큰을 통해 로그인 유저 정보를 가져옴
+//		User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
+//		RecipeResponse updatedRecipe = recipeService.updateRecipe(RecipeRequest, file, user);
+		RecipeResponse updatedRecipe = recipeService.updateRecipe(recipeRequest, file);
+		
+		return ResponseEntity.ok(updatedRecipe);
+	}
+	
+	
+	// 레시피 삭제
+	@DeleteMapping("/{id}")
+	public ResponseEntity<RecipeResponse> removeRecipe(@PathVariable("id") Long id) {
+//		// 로그인 유저(토큰을 통해 유저 정보 가져옴)
+//		User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+//		RecipeResponse deletedRecipe = recipeService.deleteProduct(id, user);
+		RecipeResponse deletedRecipe = recipeService.deleteRecipe(id);
+
+//		ProductResponse deletedProduct = productService.deleteProduct(id);
+		
+		return ResponseEntity.ok(deletedRecipe);
+	}
+		
+
+	
+	
+	
+	
+	
+	
+	
+	
+	
 }

--- a/costcook/src/main/java/com/costcook/domain/dto/FileDTO.java
+++ b/costcook/src/main/java/com/costcook/domain/dto/FileDTO.java
@@ -1,0 +1,30 @@
+package com.costcook.domain.dto;
+
+import com.costcook.entity.ImageFile;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class FileDTO {
+
+	private Long id;
+	private String origin, saved, kbSize;
+	private Long size;
+	
+	public static FileDTO toDTO(ImageFile imageFile) {
+		if (imageFile == null) return null;
+		return FileDTO.builder()
+				.id(imageFile.getId())
+				.origin(imageFile.getOriginalName())
+				.saved(imageFile.getSavedName())
+				.kbSize(((Double) (imageFile.getFileSize() / 1024.0)).toString())
+				.build();
+	}
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/domain/request/RecipeRequest.java
+++ b/costcook/src/main/java/com/costcook/domain/request/RecipeRequest.java
@@ -1,0 +1,34 @@
+package com.costcook.domain.request;
+
+import com.costcook.entity.ImageFile;
+import com.costcook.entity.Recipe;
+
+import lombok.Data;
+
+@Data
+public class RecipeRequest {
+
+	private Long id, categoryId;
+	private String title, description;
+	private int servings, price;
+	private double avgRatings;
+	
+//	private Long authorId;
+	private ImageFile imageFile;
+	
+//	public Recipe toEntity(User author) {
+	public Recipe toEntity() {
+		return Recipe.builder()
+				.title(title)
+				.description(description)
+				.servings(servings)
+				.price(price)
+				.avgRatings(avgRatings)
+//				.author(author)
+				.image(imageFile)
+				.build();
+		
+	}
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
@@ -2,6 +2,7 @@ package com.costcook.domain.response;
 
 import java.time.format.DateTimeFormatter;
 
+import com.costcook.domain.dto.FileDTO;
 import com.costcook.entity.Recipe;
 
 import lombok.Builder;
@@ -18,7 +19,7 @@ public class RecipeResponse {
 	private double avgRatings;
 	
 //	private UserResponse author;
-//	private FileDTO image;
+	private FileDTO image;
 	
 	// Recipe -> response 변환
 	public static RecipeResponse toDTO(Recipe recipe) {
@@ -28,14 +29,20 @@ public class RecipeResponse {
 				.rcpSno(recipe.getRcpSno())
 				.title(recipe.getTitle())
 				.description(recipe.getDescription())
-				.createdAt(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
-				.createdAt(recipe.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+//				.createdAt(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+				.createdAt(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")))
+//				.createdAt(recipe.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+				.createdAt(recipe.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")))
 				.servings(recipe.getServings())
 				.price(recipe.getPrice())
 				.viewCount(recipe.getViewCount())
 				.bookmarkCount(recipe.getBookmarkCount())
 				.commentCount(recipe.getCommentCount())
 				.avgRatings(recipe.getAvgRatings())
+				
+//				.author(UserResponse.toDTO(recipe.getAuthor()))
+				.image(FileDTO.toDTO(recipe.getImage()))
+				
 				.build();
 	}
 	

--- a/costcook/src/main/java/com/costcook/entity/ImageFile.java
+++ b/costcook/src/main/java/com/costcook/entity/ImageFile.java
@@ -1,0 +1,41 @@
+package com.costcook.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class ImageFile {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(updatable = false)
+	private Long id;
+	
+	@Column(nullable = false, name = "original_name")
+	private String originalName;
+	
+	@Column(nullable = false, name = "saved_name")
+	private String savedName;
+	
+	@Column(nullable = false, name = "file_size")
+	private Long fileSize;
+
+	
+	@Builder
+	public ImageFile(String originalName, String savedName, Long fileSize) {
+		this.originalName = originalName;
+		this.savedName = savedName;
+		this.fileSize = fileSize;
+	}
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/entity/Recipe.java
+++ b/costcook/src/main/java/com/costcook/entity/Recipe.java
@@ -2,6 +2,7 @@ package com.costcook.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +13,9 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -23,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(name = "recipes")
 public class Recipe {
 	
 	@Id
@@ -35,29 +40,32 @@ public class Recipe {
 	private Long categoryId;
 	
 	// 만개 레시피 제공 데이터 고유번호
-	@Column
-	private int rcpSno;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int rcpSno = 0;
 	
 	// 레시피 이름
 	@Column(nullable = false)
 	private String title;
 	
-//	// 레시피 이미지
-//	@JoinColumn(name = "image_id", nullable = true)
-//	@ManyToOne
-//	private ImageFile image;
+	// 레시피 이미지
+	@JoinColumn(name = "image_id", nullable = true)
+	@ManyToOne
+	private ImageFile image;
 	
 	// 레시피 설명 (null 허용)
 	@Column(nullable = true)
 	private String description;
 	
 	// 몇인분 (디폴트 1)
-	@Column
-	private int servings;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int servings = 1;
 	
 	// 가격
-	@Column
-	private int price;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int price = 0;
 	
 	// 등록일
 	@CreatedDate
@@ -70,20 +78,24 @@ public class Recipe {
 	private LocalDateTime updatedAt;
 	
 	// 조회수 (디폴트 0)
-	@Column
-	private int viewCount;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int viewCount = 0;
 	
 	// 즐겨찾기 수 (디폴트 0)
-	@Column
-	private int bookmarkCount;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int bookmarkCount = 0;
 	
 	// 댓글 수 (디폴트 0)
-	@Column
-	private int commentCount;
+	@Column(nullable = false)
+	@Builder.Default()
+	private int commentCount = 0;
 	
 	// 평점 (디폴트 0.0)
-	@Column
-	private double avgRatings;
+	@Column(nullable = false)
+	@Builder.Default()
+	private double avgRatings = 0.0;
 	
 	
 

--- a/costcook/src/main/java/com/costcook/repository/ImageFileRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/ImageFileRepository.java
@@ -1,0 +1,13 @@
+package com.costcook.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.costcook.entity.ImageFile;
+
+@Repository
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+	
+	
+
+}

--- a/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import com.costcook.entity.Recipe;
 
 @Repository
-public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
 	
 }

--- a/costcook/src/main/java/com/costcook/service/ImageFileService.java
+++ b/costcook/src/main/java/com/costcook/service/ImageFileService.java
@@ -1,0 +1,18 @@
+package com.costcook.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.costcook.domain.dto.FileDTO;
+import com.costcook.entity.ImageFile;
+
+public interface ImageFileService {
+	
+	public ImageFile saveImage(MultipartFile file);
+
+	FileDTO getImageByImageId(Long id);
+	
+	
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/service/RecipeService.java
+++ b/costcook/src/main/java/com/costcook/service/RecipeService.java
@@ -1,13 +1,26 @@
 package com.costcook.service;
 
+
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.costcook.domain.request.RecipeRequest;
 import com.costcook.domain.response.RecipeResponse;
 
 public interface RecipeService {
 
-	List<RecipeResponse> getAllRecipe();
+	Page<RecipeResponse> getAllRecipes(Pageable pageable, Long id);
 
 	RecipeResponse getRecipeById(Long id);
+
+	RecipeResponse insertRecipe(RecipeRequest recipeRequest, MultipartFile file);
+
+	RecipeResponse updateRecipe(RecipeRequest recipeRequest, MultipartFile file);
+
+	RecipeResponse deleteRecipe(Long id);
+
 
 }

--- a/costcook/src/main/java/com/costcook/service/impl/ImageFileServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/ImageFileServiceImpl.java
@@ -1,0 +1,48 @@
+package com.costcook.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.costcook.domain.dto.FileDTO;
+import com.costcook.entity.ImageFile;
+import com.costcook.repository.ImageFileRepository;
+import com.costcook.service.ImageFileService;
+import com.costcook.util.FileUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageFileServiceImpl implements ImageFileService {
+	
+	private final ImageFileRepository ir;
+	private final FileUtils fileUtils;
+	
+	@Override
+	public ImageFile saveImage(MultipartFile file) {
+			
+		if (file != null) {
+			// 파일 저장 후, 저장된 imageFile 객체 가져오기
+			ImageFile imageFile = fileUtils.fileUpload(file);
+			
+			if (imageFile != null) {
+				ImageFile savedImageFile = ir.save(imageFile);
+				return savedImageFile;
+			}			
+		}
+		return null;
+	}
+	
+	
+	// 이미지 다운로드
+	@Override
+	public FileDTO getImageByImageId(Long id) {
+		ImageFile image = ir.findById(id)
+				.orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없음"));
+		return FileDTO.toDTO(image);
+	}
+	
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
@@ -1,13 +1,22 @@
 package com.costcook.service.impl;
 
-import java.util.List;
+import java.util.Collections;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.costcook.domain.request.RecipeRequest;
 import com.costcook.domain.response.RecipeResponse;
+import com.costcook.entity.ImageFile;
+import com.costcook.entity.Recipe;
 import com.costcook.repository.RecipeRepository;
+import com.costcook.service.ImageFileService;
 import com.costcook.service.RecipeService;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,18 +26,106 @@ import lombok.extern.slf4j.Slf4j;
 public class RecipeServiceImpl implements RecipeService {
 	
 	private final RecipeRepository recipeRepository;
-
+	private final ImageFileService imageFileService;
+	
+	// 레시피 등록
 	@Override
-	public List<RecipeResponse> getAllRecipe() {
-		// TODO Auto-generated method stub
-		return null;
+	public RecipeResponse insertRecipe(RecipeRequest recipeRequest, MultipartFile file) {
+		// 이미지 저장
+		ImageFile savedImage = imageFileService.saveImage(file);
+		if (savedImage != null) recipeRequest.setImageFile(savedImage); 
+//		// 상품 추가 (관리자) // 현재 로그인한 유저의 ID로 지정
+//		User user = userRepository.findById(loginedUser.getId()) 
+//				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+		
+//		Recipe recipe = recipeRequest.toEntity(user);
+		Recipe recipe = recipeRequest.toEntity();
+		Recipe savedRecipe = recipeRepository.save(recipe);
+		RecipeResponse result = RecipeResponse.toDTO(savedRecipe);
+		
+		return result;
 	}
+	
 
+	// 레시피 전체 목록
+	@Override
+	public Page<RecipeResponse> getAllRecipes(Pageable pageable, Long id) {
+		// 레시피 목록 + 페이지네이션
+        if (id != null) {
+            // 특정 ID에 해당하는 레시피를 가져오려는 경우
+            return recipeRepository.findById(id)
+                    .map(recipe -> {
+                        RecipeResponse recipeResponse = RecipeResponse.toDTO(recipe);
+                        return new PageImpl<>(Collections.singletonList(recipeResponse), pageable, 1L); // 반환 타입 명시
+                    })
+                    .orElseThrow(() -> new EntityNotFoundException("레시피 데이터를 불러올 수 없습니다."));
+        }
+		return recipeRepository.findAll(pageable).map(RecipeResponse::toDTO); // 전체 레시피를 페이지네이션해서 가져옴
+	}
+	
+	
+	
+	
+
+	// 특정 레시피 조회
 	@Override
 	public RecipeResponse getRecipeById(Long id) {
-		// TODO Auto-generated method stub
-		return null;
+		Recipe product = recipeRepository.findById(id)
+				.orElseThrow(() -> new IllegalArgumentException("제품 정보가 없습니다."));
+		RecipeResponse productResponse = RecipeResponse.toDTO(product);
+		return productResponse;
 	}
+
+
+	// 레시피 수정
+	@Override
+//	public RecipeResponse updateRecipe(RecipeRequest recipeRequest, MultipartFile file, User loginedUser) {
+	public RecipeResponse updateRecipe(RecipeRequest recipeRequest, MultipartFile file) {
+		// 수정 전 정보
+		Recipe recipe = recipeRepository.findById(recipeRequest.getId())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+//		// 관리자 여부 확인
+//		if (!loginedUser.getRole().name().equals("ROLE_ADMIN")) {
+//			throw new IllegalArgumentException("관리자만 수정할 수 있습니다.");
+//		}
+		
+		// 이미지 수정
+		ImageFile savedImage = imageFileService.saveImage(file);
+		
+		// 수정하지 않을 경우 그대로 놔두기(null)
+		if (savedImage != null) recipe.setImage(savedImage);
+		if (recipeRequest.getTitle() != null) recipe.setTitle(recipeRequest.getTitle());
+		if (recipeRequest.getDescription() != null) recipe.setDescription(recipeRequest.getDescription());
+		if (recipeRequest.getServings() != recipe.getServings()) recipe.setServings(recipeRequest.getServings());
+		if (recipeRequest.getPrice() != recipe.getPrice()) recipe.setPrice(recipeRequest.getPrice());
+		if (recipeRequest.getAvgRatings() != recipe.getAvgRatings()) recipe.setAvgRatings(recipeRequest.getAvgRatings());
+		
+		Recipe updatedRecipe = recipeRepository.save(recipe);
+		RecipeResponse result = RecipeResponse.toDTO(updatedRecipe);
+		
+		return result;
+	}
+
+
+	// 레시피 삭제
+	@Override
+//	public RecipeResponse deleteRecipe(Long id, User loginedUser) {
+	public RecipeResponse deleteRecipe(Long id) {
+		// 상품 원본 정보 가져오기
+		Recipe recipe = recipeRepository.findById(id)
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 레시피입니다."));
+//		// 관리자만 삭제 가능하게
+//		if (!loginedUser.getRole().name().equals("ROLE_ADMIN")) {
+//			throw new IllegalArgumentException("관리자만 삭제할 수 있습니다.");
+//		}
+		recipeRepository.delete(recipe);
+		
+		return RecipeResponse.toDTO(recipe);
+	}
+
+
+
+
 	
 
 }

--- a/costcook/src/main/java/com/costcook/util/FileUtils.java
+++ b/costcook/src/main/java/com/costcook/util/FileUtils.java
@@ -1,0 +1,54 @@
+package com.costcook.util;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.costcook.entity.ImageFile;
+
+
+// 이미지 업로드, 수정 관련 클래스
+@Component
+public class FileUtils {
+
+	// application.yml의 location 정보 가져오기
+	@Value("${spring.upload.location}")
+	private String uploadPath;
+	
+	public ImageFile fileUpload(MultipartFile file) {
+		
+		try {		
+			String originalFileName = file.getOriginalFilename(); // 원본 파일명 가져오기
+			Long fileSize = file.getSize(); // 파일 크기 가져오기			
+			String savedFileName = UUID.randomUUID() + "_" + originalFileName; // 새로운 파일명 가져오기
+			
+			// 파일 저장
+			InputStream inputStream = file.getInputStream();	
+			Path path = Paths.get(uploadPath).resolve(savedFileName); // 저장 경로 설정
+			
+			// 이미 있는 경우 덮어쓰기
+			Files.copy(inputStream, path, StandardCopyOption.REPLACE_EXISTING);
+			
+			// 새 ImageFile 반환
+			return ImageFile.builder()
+					.originalName(originalFileName)
+					.savedName(savedFileName)
+					.fileSize(fileSize)
+					.build();
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+		
+	}
+	
+	
+}


### PR DESCRIPTION
## 작업 내용 (What)
레시피 페이지 목록 조회, 정렬, 페이지네이션(커서) API 구현

## 작업 이유 (Why)
레시피를 목록을 나열할 때 특정한 기준으로 정렬해서 볼 필요가 있음,
레시피 데이터 추가 로드 시 커서방식으로 추가 페이지에 추가 데이터를 출력하는 것이 오프셋 방식보다 편리함

## 변경 사항 (Changes)
RecipeController > getAllRecipe > 매개변수 추가(page, size, sort, order), 정렬 기준에 따른 Pageable 코드 추가
레시피 타입 List -> Page 변경

기타 코드 변경: recipes 테이블의 데이터값에 디폴트 값이 입력되도록 Integer 타입 -> int 변경

## 테스트 결과 (Test Result)
postman 실행 완료 (api예시 : http://localhost:8080/api/recipes?page=1&size=9&sort=avgRatings&order=desc )

[사진]
![377380050-5fd69725-1e07-4d19-81d5-45df651b9f40](https://github.com/user-attachments/assets/4d10b225-4770-40f7-a989-b31bb35b5fce)


## 추가 사항 (Additional Info)

ImageFile 테이블 삭제 후 recipes 테이블 컬럼으로 통합 예정

프론트엔드 내 정렬, 페이지네이션 작업 중