### PR TITLE
Feat: 구글/카카오 로그인 시 필요한 API 구현

### DIFF
--- a/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
+++ b/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
@@ -1,0 +1,63 @@
+package com.costcook.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+	// HTTP 요청에 따른 보안 구성
+	@Bean
+	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		
+		// 경로 권한 설정
+		http.authorizeHttpRequests(auth ->
+			// 특정 URL 경로에 대해서는 인증 없이 접근 가능
+			auth.requestMatchers(
+				new AntPathRequestMatcher("/api/oauth/**"),
+				new AntPathRequestMatcher("/api/auth/signup")
+			).permitAll()
+			// 그 밖의 다른 요청들은 인증을 통과한(로그인한) 사용자라면 모두 접근할 수 있도록 한다.
+			.anyRequest().authenticated()
+		);
+		
+		// 무상태성 세션 관리
+		http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+		
+		// HTTP 기본 설정
+		http.httpBasic(HttpBasicConfigurer::disable);
+		// CSRF 비활성화
+		http.csrf(AbstractHttpConfigurer::disable);
+		// CORS 설정
+		http.cors(corsConfig -> corsConfig.configurationSource(corsConfigurationSource()));
+		
+		return http.getOrBuild();
+	}
+	
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		return request -> {
+			CorsConfiguration config = new CorsConfiguration();
+			config.setAllowedHeaders(Collections.singletonList("*"));
+			config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+			config.setAllowedOrigins(List.of("http://localhost:3000"));
+			config.setAllowCredentials(true);
+			return config;
+		};
+	}
+}

--- a/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
+++ b/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
@@ -10,10 +10,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+
+import com.costcook.security.JwtProperties;
+import com.costcook.security.JwtProvider;
+import com.costcook.util.TokenUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +26,18 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class WebSecurityConfig {
+	private final JwtProperties	jwtProperties;
+	private final UserDetailsService userDetailsService;
+	
+	// JWT PROVIDER 생성자 호출
+	private JwtProvider jwtProvider() {
+		return new JwtProvider(userDetailsService, jwtProperties);
+	}
+	// TokenUtils 생성자 호출
+	private TokenUtils tokenUtils() {
+		return new TokenUtils(jwtProvider());
+	}
+	
 	// HTTP 요청에 따른 보안 구성
 	@Bean
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
+++ b/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
@@ -30,7 +30,7 @@ public class WebSecurityConfig {
 			// 특정 URL 경로에 대해서는 인증 없이 접근 가능
 			auth.requestMatchers(
 				new AntPathRequestMatcher("/api/oauth/**"),
-				new AntPathRequestMatcher("/api/auth/signup")
+				new AntPathRequestMatcher("/api/auth/**")
 			).permitAll()
 			// 그 밖의 다른 요청들은 인증을 통과한(로그인한) 사용자라면 모두 접근할 수 있도록 한다.
 			.anyRequest().authenticated()

--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.costcook.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.costcook.domain.request.SignUpOrLoginRequest;
+import com.costcook.service.AuthService;
+import com.costcook.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	private final AuthService authService;
+	
+	@PostMapping("/signup-or-login")
+    public ResponseEntity<?> signUpOrLogin(@RequestBody SignUpOrLoginRequest signUpOrLoginRequest) {
+		// 1. authRequest 필드 유효성 검증
+		authService.signUpOrLogin(signUpOrLoginRequest);
+		
+		
+    	return ResponseEntity.ok("signup or login");
+    }
+}

--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -1,37 +1,42 @@
 package com.costcook.controller;
 
+import java.util.Map;
+import java.util.Random;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.service.AuthService;
 import com.costcook.domain.request.EmailRequest;
+import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.request.VerificationRequest;
+import com.costcook.domain.response.SignUpOrLoginResponse;
 import com.costcook.domain.response.VerifyCodeResponse;
 import com.costcook.service.EmailService;
 import com.costcook.util.EmailUtil;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
 	private final AuthService authService;
     private final EmailService emailService;
 	
 	@PostMapping("/signup-or-login")
-    public ResponseEntity<?> signUpOrLogin(@RequestBody SignUpOrLoginRequest signUpOrLoginRequest) {
-		// 1. authRequest 필드 유효성 검증
-		authService.signUpOrLogin(signUpOrLoginRequest);
-		
-		
-    	return ResponseEntity.ok("signup or login");
+    public ResponseEntity<?> signUpOrLogin(@RequestBody SignUpOrLoginRequest signUpOrLoginRequest, HttpServletResponse response) {
+		SignUpOrLoginResponse signUpOrLoginResponse = authService.signUpOrLogin(signUpOrLoginRequest);
+    	return ResponseEntity.ok(signUpOrLoginResponse);
     }
 
 	@PostMapping("/send-verification-code")

--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
 	
 	@PostMapping("/signup-or-login")
     public ResponseEntity<?> signUpOrLogin(@RequestBody SignUpOrLoginRequest signUpOrLoginRequest, HttpServletResponse response) {
-		SignUpOrLoginResponse signUpOrLoginResponse = authService.signUpOrLogin(signUpOrLoginRequest);
+		SignUpOrLoginResponse signUpOrLoginResponse = authService.signUpOrLogin(signUpOrLoginRequest, response);
     	return ResponseEntity.ok(signUpOrLoginResponse);
     }
 

--- a/costcook/src/main/java/com/costcook/controller/OAuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/OAuthController.java
@@ -1,5 +1,7 @@
 package com.costcook.controller;
 
+import java.util.Optional;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.costcook.domain.OAuthUserInfo;
 import com.costcook.domain.PlatformTypeEnum;
+import com.costcook.service.AuthService;
 import com.costcook.service.UserService;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OAuthController {
 	private final UserService userService;
+	private final AuthService authService;
 	
 	@GetMapping("")
 	public ResponseEntity<?> test() {
@@ -33,6 +37,10 @@ public class OAuthController {
 		log.info("들어온 코드 값 > {}, {}", code, provider);
 		PlatformTypeEnum platformType = PlatformTypeEnum.fromString(provider);
 		OAuthUserInfo oAuthUserInfo = userService.getOAuthUserInfo(code, platformType);
+//		이 데이터를 받기 전에 서버에서 socialKey, provider 로 social_accounts 테이블을 조회하고, social_accounts 테이블에 데이터가 있으면 user_id 를 찾아 users 테이블을 조회해서 email 값을 가져와야 한다.
+		Optional<String> email = authService.getEmailFromSocialAccount(oAuthUserInfo.getSocialKey(), oAuthUserInfo.getProvider());
+		if (email.isPresent()) oAuthUserInfo.setEmail(email.get());
+		
 		return ResponseEntity.ok(oAuthUserInfo);
 	}
 }

--- a/costcook/src/main/java/com/costcook/controller/OAuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/OAuthController.java
@@ -3,6 +3,7 @@ package com.costcook.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,11 +29,10 @@ public class OAuthController {
 	}
 
 	@GetMapping("/{provider}")
-	public ResponseEntity<?> getProviderInfo(@RequestParam("code") final String code, @PathVariable("provider") final String provider, HttpServletResponse res) {
+	public ResponseEntity<OAuthUserInfo> getProviderInfo(@RequestParam("code") final String code, @PathVariable("provider") final String provider, HttpServletResponse res) {
 		log.info("들어온 코드 값 > {}, {}", code, provider);
 		PlatformTypeEnum platformType = PlatformTypeEnum.fromString(provider);
 		OAuthUserInfo oAuthUserInfo = userService.getOAuthUserInfo(code, platformType);
 		return ResponseEntity.ok(oAuthUserInfo);
-		
 	}
 }

--- a/costcook/src/main/java/com/costcook/controller/OAuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/OAuthController.java
@@ -1,0 +1,38 @@
+package com.costcook.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.costcook.domain.OAuthUserInfo;
+import com.costcook.domain.PlatformTypeEnum;
+import com.costcook.service.UserService;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+	private final UserService userService;
+	
+	@GetMapping("")
+	public ResponseEntity<?> test() {
+		return ResponseEntity.ok("hello world");
+	}
+
+	@GetMapping("/{provider}")
+	public ResponseEntity<?> getProviderInfo(@RequestParam("code") final String code, @PathVariable("provider") final String provider, HttpServletResponse res) {
+		log.info("들어온 코드 값 > {}, {}", code, provider);
+		PlatformTypeEnum platformType = PlatformTypeEnum.fromString(provider);
+		OAuthUserInfo oAuthUserInfo = userService.getOAuthUserInfo(code, platformType);
+		return ResponseEntity.ok(oAuthUserInfo);
+		
+	}
+}

--- a/costcook/src/main/java/com/costcook/domain/OAuthUserInfo.java
+++ b/costcook/src/main/java/com/costcook/domain/OAuthUserInfo.java
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OAuthUserInfo {
-	String key; 
+	String socialKey; 
 	String email;
 	String name;
 	PlatformTypeEnum provider;
 	
 	public boolean isAbleToLogin() {
-		if (this.getKey() != null && this.getEmail() != null && this.getName() != null && this.getProvider() != null) {
+		if (this.getSocialKey() != null && this.getEmail() != null && this.getName() != null && this.getProvider() != null) {
 			return true;
 	    }
 		return false;

--- a/costcook/src/main/java/com/costcook/domain/OAuthUserInfo.java
+++ b/costcook/src/main/java/com/costcook/domain/OAuthUserInfo.java
@@ -1,0 +1,22 @@
+package com.costcook.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthUserInfo {
+	String key; 
+	String email;
+	String name;
+	PlatformTypeEnum provider;
+	
+	public boolean isAbleToLogin() {
+		if (this.getKey() != null && this.getEmail() != null && this.getName() != null && this.getProvider() != null) {
+			return true;
+	    }
+		return false;
+	}
+}

--- a/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
+++ b/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
@@ -20,6 +20,6 @@ public enum PlatformTypeEnum {
                 return authEnum;
             }
         }
-        throw new IllegalArgumentException("유효하지 않은 값입니다: " + value);
+        throw new IllegalArgumentException("적절하지 않은 소셜 로그인 제공자입니다.");
     }
 }

--- a/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
+++ b/costcook/src/main/java/com/costcook/domain/PlatformTypeEnum.java
@@ -1,6 +1,25 @@
 package com.costcook.domain;
 
 public enum PlatformTypeEnum {
-    KAKAO,
-    GOOGLE
+	KAKAO("kakao"),
+	GOOGLE("google");
+	
+	String auth;
+	
+	PlatformTypeEnum(String auth) {
+		this.auth = auth;
+	}
+	
+	public String getAuth() {
+		return auth;
+	}
+	
+	public static PlatformTypeEnum fromString(String value) {
+        for (PlatformTypeEnum authEnum : PlatformTypeEnum.values()) {
+            if (authEnum.getAuth().equalsIgnoreCase(value)) {
+                return authEnum;
+            }
+        }
+        throw new IllegalArgumentException("유효하지 않은 값입니다: " + value);
+    }
 }

--- a/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
+++ b/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
@@ -1,10 +1,21 @@
 package com.costcook.domain.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class SignUpOrLoginRequest {
-    private String socialKey;        // provider_user_id
-    private String email;      // 사용자 이메일
-    private String provider;   // 소셜 로그인 제공자 (kakao, google)
+
+    // 소셜 로그인 키 (Google, Kakao 등의 고유 식별자)
+    private String socialKey;
+
+    // 이메일 주소
+    private String email;
+
+    // 제공자 (소셜 로그인 제공자, 예: 'KAKAO', 'GOOGLE')
+    private String provider;
 }
+

--- a/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
+++ b/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
@@ -1,0 +1,10 @@
+package com.costcook.domain.request;
+
+import lombok.Data;
+
+@Data
+public class SignUpOrLoginRequest {
+    private String socialKey;        // provider_user_id
+    private String email;      // 사용자 이메일
+    private String provider;   // 소셜 로그인 제공자 (kakao, google)
+}

--- a/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginResponse.java
@@ -1,0 +1,22 @@
+package com.costcook.domain.request;
+
+import lombok.Data;
+
+@Data
+public class SignUpOrLoginResponse {
+    private String message;
+    private String accessToken;
+    private String refreshToken;
+    private boolean isNewUser;
+
+    public SignUpOrLoginResponse(String message) {
+        this.message = message;
+    }
+
+    public SignUpOrLoginResponse(String message, String accessToken, String refreshToken, boolean isNewUser) {
+        this.message = message;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.isNewUser = isNewUser;
+    }
+}

--- a/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
@@ -1,4 +1,4 @@
-package com.costcook.domain.request;
+package com.costcook.domain.response;
 
 import lombok.Data;
 

--- a/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
@@ -1,22 +1,18 @@
 package com.costcook.domain.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
+@AllArgsConstructor
 public class SignUpOrLoginResponse {
     private String message;
     private String accessToken;
-    private String refreshToken;
     private boolean isNewUser;
 
     public SignUpOrLoginResponse(String message) {
         this.message = message;
-    }
-
-    public SignUpOrLoginResponse(String message, String accessToken, String refreshToken, boolean isNewUser) {
-        this.message = message;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-        this.isNewUser = isNewUser;
     }
 }

--- a/costcook/src/main/java/com/costcook/entity/SocialAccount.java
+++ b/costcook/src/main/java/com/costcook/entity/SocialAccount.java
@@ -17,8 +17,9 @@ import com.costcook.domain.PlatformTypeEnum;
 @Table(name = "social_accounts")
 @EntityListeners(AuditingEntityListener.class) // 생성, 수정 날짜 추적 -> Application.java (@EnableJpaAuditing)
 @Data
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class SocialAccount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +32,7 @@ public class SocialAccount {
     @Enumerated(EnumType.STRING)
     @Column(name = "provider")
     @Builder.Default
-    private PlatformTypeEnum provider; // 플랫폼 타입 (KAKAO, GOOGLE)
+    private PlatformTypeEnum provider = PlatformTypeEnum.GOOGLE; // 플랫폼 타입 (KAKAO, GOOGLE)
 
     @Column(name = "social_key", length = 255, nullable = true)
     private String socialKey; // 소셜 키

--- a/costcook/src/main/java/com/costcook/entity/SocialAccount.java
+++ b/costcook/src/main/java/com/costcook/entity/SocialAccount.java
@@ -17,8 +17,8 @@ import com.costcook.domain.PlatformTypeEnum;
 @Table(name = "social_accounts")
 @EntityListeners(AuditingEntityListener.class) // 생성, 수정 날짜 추적 -> Application.java (@EnableJpaAuditing)
 @Data
-@Builder
 @AllArgsConstructor
+@Builder
 public class SocialAccount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/costcook/src/main/java/com/costcook/entity/SocialAccount.java
+++ b/costcook/src/main/java/com/costcook/entity/SocialAccount.java
@@ -1,18 +1,24 @@
 package com.costcook.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.costcook.domain.PlatformTypeEnum;
 
 @Entity
 @Table(name = "social_accounts")
+@EntityListeners(AuditingEntityListener.class) // 생성, 수정 날짜 추적 -> Application.java (@EnableJpaAuditing)
 @Data
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
 public class SocialAccount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,13 +29,19 @@ public class SocialAccount {
     private User user; // 사용자 (외래 키)
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "platform_type")
-    private PlatformTypeEnum platformType; // 플랫폼 타입 (KAKAO, GOOGLE)
+    @Column(name = "provider")
+    @Builder.Default
+    private PlatformTypeEnum provider; // 플랫폼 타입 (KAKAO, GOOGLE)
 
-    @Column(name = "social_key", length = 255)
+    @Column(name = "social_key", length = 255, nullable = true)
     private String socialKey; // 소셜 키
 
     @CreatedDate
     @Column(name = "connected_at", nullable = false)
     private LocalDateTime connectedAt; // 연결된 시간
+    
+    @PrePersist
+    public void onCreate() {
+        this.connectedAt = LocalDateTime.now();
+    }
 }

--- a/costcook/src/main/java/com/costcook/entity/User.java
+++ b/costcook/src/main/java/com/costcook/entity/User.java
@@ -6,11 +6,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import com.costcook.domain.RoleEnum;
 import com.costcook.domain.StatusEnum;
@@ -22,7 +26,7 @@ import com.costcook.domain.StatusEnum;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class User {
+public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false) // 이 필드 값은 생성할 때만 값 설정 가능.
@@ -80,6 +84,23 @@ public class User {
     @PreUpdate
     public void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 권한 목록 반환
+		return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        throw null;
+    }
+
+    @Override
+    public String getUsername() {
+        // 로그인할 사용자 명을 이메일로 대체
+		return email;
     }    
 
 //     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/costcook/src/main/java/com/costcook/entity/User.java
+++ b/costcook/src/main/java/com/costcook/entity/User.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -37,13 +38,13 @@ public class User {
     private String profileUrl;
 
     @Column(name = "service_agreement")
-    private Boolean serviceAgreement;
+    private Boolean serviceAgreement = false;
 
     @Column(name = "privacy_policy_agreement")
-    private Boolean privacyPolicyAgreement;
+    private Boolean privacyPolicyAgreement = false;
 
     @Column(name = "additional_info_agreement")
-    private Boolean additionalInfoAgreement;
+    private Boolean additionalInfoAgreement = false;
 
     @Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -51,7 +52,7 @@ public class User {
 	private RoleEnum role = RoleEnum.ROLE_USER; // 권한 컬럼 추가 (기본값 ROLE_USER)
 
     @Column(name = "warning_count")
-    private Integer warningCount;
+    private Integer warningCount = 0;
 
     @Column(name = "refresh_token", length = 255)
     private String refreshToken; // 리프레시 토큰
@@ -81,6 +82,6 @@ public class User {
         this.updatedAt = LocalDateTime.now();
     }    
 
-    // @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    // private List<SocialAccount> socialAccounts; // 소셜 계정 리스트
+//     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//     private List<SocialAccount> socialAccounts; // 소셜 계정 리스트
 }

--- a/costcook/src/main/java/com/costcook/exceptions/InvalidProviderException.java
+++ b/costcook/src/main/java/com/costcook/exceptions/InvalidProviderException.java
@@ -1,0 +1,7 @@
+package com.costcook.exceptions;
+
+public class InvalidProviderException extends RuntimeException {
+    public InvalidProviderException(String message) {
+        super(message);
+    }
+}

--- a/costcook/src/main/java/com/costcook/exceptions/MissingFieldException.java
+++ b/costcook/src/main/java/com/costcook/exceptions/MissingFieldException.java
@@ -1,0 +1,7 @@
+package com.costcook.exceptions;
+
+public class MissingFieldException extends RuntimeException {
+    public MissingFieldException() {
+        super("필수 정보가 누락되었습니다.");
+    }
+}

--- a/costcook/src/main/java/com/costcook/repository/SocialAccountRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/SocialAccountRepository.java
@@ -4,8 +4,9 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.costcook.domain.PlatformTypeEnum;
 import com.costcook.entity.SocialAccount;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
-    Optional<SocialAccount> findBySocialKeyAndProvider(String socialKey, String provider);
+    Optional<SocialAccount> findBySocialKeyAndProvider(String socialKey, PlatformTypeEnum provider);
 }

--- a/costcook/src/main/java/com/costcook/repository/SocialAccountRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/SocialAccountRepository.java
@@ -1,0 +1,11 @@
+package com.costcook.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.costcook.entity.SocialAccount;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+    Optional<SocialAccount> findBySocialKeyAndProvider(String socialKey, String provider);
+}

--- a/costcook/src/main/java/com/costcook/repository/UserRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.costcook.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.costcook.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/costcook/src/main/java/com/costcook/security/JwtProperties.java
+++ b/costcook/src/main/java/com/costcook/security/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.costcook.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt") // application.yml에 설정한 jwt.issuer, jwt.secret_key,...이 매핑된다.
+public class JwtProperties {
+	private String issuer;
+	private String secretKey;
+	private int accessDuration;
+	private int refreshDuration;
+}

--- a/costcook/src/main/java/com/costcook/security/JwtProvider.java
+++ b/costcook/src/main/java/com/costcook/security/JwtProvider.java
@@ -1,0 +1,111 @@
+package com.costcook.security;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import com.costcook.entity.User;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtProvider {
+	private final UserDetailsService userDetailsService;
+	// JWT 관련 설정 정보 객체 주입
+	private final JwtProperties jwtProperties;
+	
+	// JWT Access 토큰 생성 메소드
+	public String generateAccessToken(User user) {
+		log.info("[generateAccessToken] 액세스 토큰을 생성합니다.");
+		Date now = new Date();
+		Date expiredDate = new Date(now.getTime() + jwtProperties.getAccessDuration());
+		return makeToken(user, expiredDate);
+	}
+	
+	// JWT Refresh 토큰 생성 메소드
+	public String generateRefreshToken(User user) {
+		log.info("[generateRefreshToken] 리프레시 토큰을 생성합니다.");
+		Date now = new Date();
+		Date expiredDate = new Date(now.getTime() + jwtProperties.getRefreshDuration());
+		return makeToken(user, expiredDate);
+	}
+	
+	// 토큰 생성 공통 메소드 (실제로 JWT 토큰 생성)
+	private String makeToken(User user, Date expiredDate) {
+		String token = Jwts.builder()
+			.header().add("typ", "JWT") // JWT 타입을 명시
+			.and()
+			.issuer(jwtProperties.getIssuer()) // 발행자 정보 설정
+			.issuedAt(new Date()) // 발행일시 설정
+			.expiration(expiredDate) // 만료 시간 설정
+			.subject(user.getEmail()) // 토큰의 주제(Subject) 설정 _ 사용자 이메일
+			.claim("id", user.getId())
+			.claim("role", user.getRole().name())
+			.signWith(getSecretKey(), Jwts.SIG.HS256) // 비밀키와 해시 알고리즘 사용하여 토큰 설명값 설정
+			.compact(); // 토큰 정보들을 최종적으로 압축해서 문자열로 반환
+		log.info("[makeToken] 완성된 토큰 : {}", token);
+		return token;
+	}	
+	
+	// 비밀키 만드는 메소드
+	private SecretKey getSecretKey() {
+		return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+	}
+	
+	// 토큰이 유효한지 검증 메소드
+	public boolean validateToken(String token) {
+		log.info("[validateToken] 토큰 검증을 시작합니다.");
+		try {
+			Jwts.parser()
+				.verifyWith(getSecretKey()) // 비밀키로 서명 검증
+				.build()
+				.parseSignedClaims(token); // 서명된 클레임을 파싱..
+			log.info("토큰 검증 통과");
+			return true;
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		log.info("토큰 검증 실패");
+		return false;
+	}
+	
+	// 토큰에서 정보(Claim) 추출 메소드
+	private Claims getClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(getSecretKey()) // 비밀키로 서명 검증
+			.build()
+			.parseSignedClaims(token) // 서명된 클레임을 파싱..
+			.getPayload(); // 파싱된 클레임에서 페이로드(실제 클레임)를 반환
+	}
+	
+	// 토큰에서 인증 정보 반환하는 메소드
+	public Authentication getAuthenticationByToken(String token) {
+		log.info("[getAuthenticationByToken] 토큰 인증 정보 조회");
+		String userEmail = getUserEmailByToken(token);
+		User user = (User) userDetailsService.loadUserByUsername(userEmail);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			user, token, user.getAuthorities()
+		);
+		return authentication;
+	}
+	
+	// 토큰에서 사용자 이메일만 추출하는 메소드
+	public String getUserEmailByToken(String token) {
+		log.info("[getUserIdByToken] 토큰 기반 회원 식별 정보 추출");
+		Claims claims = getClaims(token);
+		String email = claims.get("sub", String.class);
+		return email;
+	}
+
+}

--- a/costcook/src/main/java/com/costcook/service/AuthService.java
+++ b/costcook/src/main/java/com/costcook/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.costcook.service;
 
 import com.costcook.domain.request.SignUpOrLoginRequest;
-import com.costcook.domain.request.SignUpOrLoginResponse;
+import com.costcook.domain.response.SignUpOrLoginResponse;
 
 public interface AuthService {
 	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request);

--- a/costcook/src/main/java/com/costcook/service/AuthService.java
+++ b/costcook/src/main/java/com/costcook/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.costcook.service;
+
+import com.costcook.domain.request.SignUpOrLoginRequest;
+import com.costcook.domain.request.SignUpOrLoginResponse;
+
+public interface AuthService {
+	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request);
+}

--- a/costcook/src/main/java/com/costcook/service/AuthService.java
+++ b/costcook/src/main/java/com/costcook/service/AuthService.java
@@ -3,6 +3,8 @@ package com.costcook.service;
 import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.response.SignUpOrLoginResponse;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 public interface AuthService {
-	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request);
+	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response);
 }

--- a/costcook/src/main/java/com/costcook/service/AuthService.java
+++ b/costcook/src/main/java/com/costcook/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.costcook.service;
 
+import java.util.Optional;
+
+import com.costcook.domain.PlatformTypeEnum;
 import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.response.SignUpOrLoginResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
+	public Optional<String> getEmailFromSocialAccount(String socialKey, PlatformTypeEnum provider);
 	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response);
 }

--- a/costcook/src/main/java/com/costcook/service/UserService.java
+++ b/costcook/src/main/java/com/costcook/service/UserService.java
@@ -1,0 +1,9 @@
+package com.costcook.service;
+
+import com.costcook.domain.OAuthUserInfo;
+import com.costcook.domain.PlatformTypeEnum;
+
+public interface UserService {
+	// Provider(kakao 혹은 google) 로부터 사용자 정보(OAuthUserInfo) 추출
+	OAuthUserInfo getOAuthUserInfo(String code, PlatformTypeEnum platformType);
+}

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -29,6 +29,30 @@ public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final TokenUtils tokenUtils;
+    
+    /**
+     * 주어진 소셜 키와 공급자를 사용하여 해당 사용자의 이메일을 조회합니다.
+     *
+     * 1. 소셜 계정(social_accounts) 테이블에서 소셜 키와 공급자를 기준으로 사용자 정보를 검색합니다.
+     * 2. 사용자가 존재할 경우, 해당 사용자의 이메일을 리턴합니다.
+     *
+     * @param socialKey - 소셜 계정의 고유 키
+     * @param provider - 소셜 공급자 유형 (Kakao, Google 등)
+     * @return Optional<String> - 사용자의 이메일이 존재할 경우 해당 이메일, 그렇지 않으면 Optional.empty() 반환
+     */
+    @Override
+    public Optional<String> getEmailFromSocialAccount(String socialKey, PlatformTypeEnum provider) {
+        // social_accounts 테이블에서 socialKey와 provider를 기준으로 사용자 조회
+        Optional<SocialAccount> socialAccountOpt = socialAccountRepository.findBySocialKeyAndProvider(socialKey, provider);
+        
+        if (socialAccountOpt.isPresent()) {
+            // 사용자 ID를 가져옴
+            User user = socialAccountOpt.get().getUser();
+            return Optional.of(user.getEmail());
+        }
+        
+        return Optional.empty(); // 사용자를 찾지 못한 경우
+    }
 
     @Override
     public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response) {

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -25,79 +25,82 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
-	private final UserRepository userRepository;
-	private final SocialAccountRepository socialAccountRepository;
-	private final TokenUtils tokenUtils;
-	
-	@Override
-	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response) {
-		// 1. Request DTO 유효성 검증
-		validateSignUpOrLoginRequest(request);
+    private final UserRepository userRepository;
+    private final SocialAccountRepository socialAccountRepository;
+    private final TokenUtils tokenUtils;
 
-		// 2. email 필드를 기준으로 회원 가입 여부 확인
-		// - 회원이 이미 존재하는 경우 로그인 처리
-		// - 신규 회원인 경우 회원가입 처리
-		User user = userRepository.findByEmail(request.getEmail())
+    @Override
+    public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response) {
+        // 1. Request DTO 유효성 검증
+        validateSignUpOrLoginRequest(request);
+
+        // 2. email 필드를 기준으로 회원 가입 여부 확인
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseGet(() -> registerNewUser(request));
 
-		log.info("새로 가입한 회원 정보: {}", user);
-		// 3. 액세스 토큰, 리프레시 토큰 발급
-		Map<String, String> tokenMap = tokenUtils.generateToken(user);
-		String accessToken = tokenMap.get("accessToken");
-		String refreshToken = tokenMap.get("refreshToken");
-		log.info("새로 발급된 액세스 토큰: {}", accessToken);
-		log.info("새로 발급된 리프레시 토큰: {}", refreshToken);
-		
-		// 4. 발급된 리프레시 토큰 사용자 테이블에 저장.
-		user.setRefreshToken(refreshToken);
-		userRepository.save(user);
-		
-		// 5. 응답
-		// 생성된 리프레시 토큰을 cookie에 담아 응답
-		tokenUtils.setRefreshTokenCookie(response, refreshToken);
-		tokenUtils.setAccessTokenCookie(response, accessToken);
-		
-		// SignUpOrLoginResponse 객체 생성
-	    boolean isNewUser = user.getCreatedAt().isAfter(LocalDateTime.now().minusMinutes(1)); // 1분 이내에 생성된 경우 신규 사용자로 간주
-	    SignUpOrLoginResponse signUpOrLoginResponse = SignUpOrLoginResponse.builder()
-	    		.message(isNewUser ? "회원가입 후 로그인이 완료되었습니다." : "로그인에 성공했습니다.")
-	            .accessToken(accessToken)
-	            .isNewUser(isNewUser)
-	            .build();
-		return signUpOrLoginResponse;
-	}
+        log.info("새로 가입한 회원 정보: {}", user);
 
-	private void validateSignUpOrLoginRequest(SignUpOrLoginRequest request) {
-		log.info(request.toString());
-		if (request.getSocialKey() == null || request.getEmail() == null || request.getProvider() == null) {
-			throw new MissingFieldException();
-		}
+        // 3. 액세스 토큰, 리프레시 토큰 발급
+        Map<String, String> tokenMap = tokenUtils.generateToken(user);
+        String accessToken = tokenMap.get("accessToken");
+        String refreshToken = tokenMap.get("refreshToken");
+        log.info("새로 발급된 액세스 토큰: {}", accessToken);
+        log.info("새로 발급된 리프레시 토큰: {}", refreshToken);
+        
+        // 4. 발급된 리프레시 토큰 사용자 테이블에 저장
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+        
+        // 5. 쿠키에 생성된 리프레시 토큰과 액세스 토큰을 담아 응답
+        tokenUtils.setRefreshTokenCookie(response, refreshToken);
+        tokenUtils.setAccessTokenCookie(response, accessToken);
+        
+        // SignUpOrLoginResponse 객체 생성
+        boolean isNewUser = user.getCreatedAt().isAfter(LocalDateTime.now().minusMinutes(1)); // 1분 이내에 생성된 경우 신규 사용자로 간주
+        SignUpOrLoginResponse signUpOrLoginResponse = SignUpOrLoginResponse.builder()
+                .message(isNewUser ? "회원가입 후 로그인이 완료되었습니다." : "로그인에 성공했습니다.")
+                .accessToken(accessToken)
+                .isNewUser(isNewUser)
+                .build();
+        
+        return signUpOrLoginResponse;
+    }
 
-		if (!isValidProvider(request.getProvider())) {
-			throw new InvalidProviderException("적절하지 않은 소셜 로그인 제공자입니다.");
-		}
-	}
+    // SignUpOrLoginRequest의 필수 필드를 검증
+    private void validateSignUpOrLoginRequest(SignUpOrLoginRequest request) {
+        log.info(request.toString());
+        if (request.getSocialKey() == null || request.getEmail() == null || request.getProvider() == null) {
+            throw new MissingFieldException();
+        }
 
-	private boolean isValidProvider(String provider) {
-		return provider.equals("kakao") || provider.equals("google");
-	}
-	
-	private User registerNewUser(SignUpOrLoginRequest request) {
+        if (!isValidProvider(request.getProvider())) {
+            throw new InvalidProviderException("적절하지 않은 소셜 로그인 제공자입니다.");
+        }
+    }
+
+    // 지원되는 소셜 로그인 제공자인지 확인
+    private boolean isValidProvider(String provider) {
+        return provider.equals("kakao") || provider.equals("google");
+    }
+    
+    // 신규 사용자 등록 및 소셜 계정 정보 저장
+    private User registerNewUser(SignUpOrLoginRequest request) {
         User newUser = new User();
         newUser.setEmail(request.getEmail());
         // 추가적인 사용자 정보 설정...
+        
+        // 신규 사용자 저장
         User savedUser = userRepository.save(newUser);
 
         // 소셜 계정 정보 저장
         SocialAccount socialAccount = SocialAccount
-        	.builder()
-        	.provider(PlatformTypeEnum.fromString(request.getProvider()))
-        	.socialKey(request.getSocialKey())
-        	.user(savedUser)
-        	.build();
+                .builder()
+                .provider(PlatformTypeEnum.fromString(request.getProvider()))
+                .socialKey(request.getSocialKey())
+                .user(savedUser)
+                .build();
         socialAccountRepository.save(socialAccount);
 
         return savedUser;
     }
-
 }

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.costcook.domain.PlatformTypeEnum;
 import com.costcook.domain.request.SignUpOrLoginRequest;
-import com.costcook.domain.request.SignUpOrLoginResponse;
+import com.costcook.domain.response.SignUpOrLoginResponse;
 import com.costcook.entity.SocialAccount;
 import com.costcook.entity.User;
 import com.costcook.exceptions.InvalidProviderException;

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -1,0 +1,75 @@
+package com.costcook.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.costcook.domain.PlatformTypeEnum;
+import com.costcook.domain.request.SignUpOrLoginRequest;
+import com.costcook.domain.request.SignUpOrLoginResponse;
+import com.costcook.entity.SocialAccount;
+import com.costcook.entity.User;
+import com.costcook.exceptions.InvalidProviderException;
+import com.costcook.exceptions.MissingFieldException;
+import com.costcook.repository.SocialAccountRepository;
+import com.costcook.repository.UserRepository;
+import com.costcook.service.AuthService;
+import com.costcook.util.OAuth2Properties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+	private final UserRepository userRepository;
+	private final SocialAccountRepository socialAccountRepository;
+	
+	@Override
+	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request) {
+		// 1. Request DTO 유효성 검증
+		validateSignUpOrLoginRequest(request);
+
+		// 2. email 필드를 기준으로 회원 가입 여부 확인
+		// - 회원이 이미 존재하는 경우 로그인 처리
+		// - 신규 회원인 경우 회원가입 처리
+		User user = userRepository.findByEmail(request.getEmail())
+                .orElseGet(() -> registerNewUser(request));
+
+		log.info("새로 가입한 회원 정보: {}", user);
+		// 3. 액세스 토큰, 리프레시 토큰 발급
+		return null;
+	}
+
+	private void validateSignUpOrLoginRequest(SignUpOrLoginRequest request) {
+		if (request.getSocialKey() == null || request.getEmail() == null || request.getProvider() == null) {
+			throw new MissingFieldException();
+		}
+
+		if (!isValidProvider(request.getProvider())) {
+			throw new InvalidProviderException("적절하지 않은 소셜 로그인 제공자입니다.");
+		}
+	}
+
+	private boolean isValidProvider(String provider) {
+		return provider.equals("kakao") || provider.equals("google");
+	}
+	
+	private User registerNewUser(SignUpOrLoginRequest request) {
+        User newUser = new User();
+        newUser.setEmail(request.getEmail());
+        // 추가적인 사용자 정보 설정...
+        User savedUser = userRepository.save(newUser);
+
+        // 소셜 계정 정보 저장
+        SocialAccount socialAccount = SocialAccount
+        	.builder()
+        	.provider(PlatformTypeEnum.fromString(request.getProvider()))
+        	.socialKey(request.getSocialKey())
+        	.user(savedUser)
+        	.build();
+        socialAccountRepository.save(socialAccount);
+
+        return savedUser;
+    }
+
+}

--- a/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
@@ -1,0 +1,271 @@
+package com.costcook.service.impl;
+
+import java.util.Map;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.costcook.domain.OAuthUserInfo;
+import com.costcook.domain.PlatformTypeEnum;
+import com.costcook.service.UserService;
+import com.costcook.util.OAuth2Properties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+	private final OAuth2Properties oAuth2Properties;
+
+	/**
+	 * OAuth provider에서 code를 통해 access token을 가져오고, 그 access token으로 사용자 정보를 추출한 후 OAuthUserInfo 객체로 반환한다.
+	 * @param code - OAuth provider에서 전달된 인증 코드
+	 * @param platformType - OAuth 플랫폼 유형 (Kakao, Google 등)
+	 * @return OAuthUserInfo - 사용자 정보 (key, email, name, platformType)
+	 */
+	@Override
+	public OAuthUserInfo getOAuthUserInfo(String code, PlatformTypeEnum platformType) {
+		// 1. code를 통해 provider에서 제공하는 accessToken 가져온다.
+		String accessTokenFromProvider = fetchAccessTokenFromProvider(code, platformType);
+		log.info("provider 에서 제공하는 accessToken 값: {}", accessTokenFromProvider);
+		
+		// 2. provider에서 제공하는 accessToken으로 oAuthUserInfo를 추출한다.
+		JsonNode oAuthUserNode = generateOAuthUserNode(accessTokenFromProvider, platformType);
+		OAuthUserInfo oAuthUserInfo = fetchOAuthUserInfo(oAuthUserNode, platformType);
+		return oAuthUserInfo;
+	}
+
+	/**
+	 * 인증 코드를 통해 OAuth provider에서 access token을 가져온다.
+	 * @param code - 인증 코드
+	 * @param platformType - OAuth 플랫폼 유형
+	 * @return accessToken - OAuth provider에서 제공한 액세스 토큰
+	 */
+	private String fetchAccessTokenFromProvider(String code, PlatformTypeEnum platformType) {
+		// 설정 가져오기
+		OAuth2Properties.Client client = getClientProperties(platformType);
+
+		// 인증코드 디코딩
+		String decodedCode = decodeCode(code);
+
+		// HTTP 요청 헤더와 파라미터 생성
+		HttpHeaders headers = createHeaders(client);
+		MultiValueMap<String, String> params = createTokenRequestParams(client, decodedCode);
+		
+		// 토큰 요청 보내기
+		ResponseEntity<Map> responseEntity = sendTokenRequest(client.getTokenUri(), headers, params);
+		
+		// 응답 검증 및 토큰 반환
+		return extractAccessToken(responseEntity);
+	}
+	
+	/**
+	 * OAuth 플랫폼 유형에 따른 클라이언트 설정을 가져온다.
+	 * @param platformType - OAuth 플랫폼 유형
+	 * @return client - 해당 플랫폼의 클라이언트 설정
+	 */
+	private OAuth2Properties.Client getClientProperties(PlatformTypeEnum platformType) {
+		OAuth2Properties.Client client = oAuth2Properties.getClients().get(platformType.getAuth());
+		logClientDetails(client);
+		return client;
+	}
+	
+	/**
+	 * 클라이언트 설정 정보를 로깅한다.
+	 * @param client - OAuth 클라이언트 설정
+	 */
+	private void logClientDetails(OAuth2Properties.Client client) {
+		log.info(client.getClientId());
+		log.info(client.getClientSecret());
+		log.info(client.getRedirectUri());
+	}
+	
+	/**
+	 * 인증 코드를 UTF-8로 디코딩한다.
+	 * @param code - 디코딩할 인증 코드
+	 * @return 디코딩된 코드
+	 */
+	private String decodeCode(String code) {
+	    return URLDecoder.decode(code, StandardCharsets.UTF_8);
+	}
+	
+	/**
+	 * 클라이언트 ID와 클라이언트 시크릿을 바탕으로 인증 헤더를 생성한다.
+	 * @param client - OAuth 클라이언트 설정
+	 * @return 생성된 HTTP 헤더
+	 */
+	private HttpHeaders createHeaders(OAuth2Properties.Client client) {
+	    HttpHeaders headers = new HttpHeaders();
+	    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+	    headers.setBasicAuth(client.getClientId(), client.getClientSecret());
+	    return headers;
+	}
+	
+	/**
+	 * 액세스 토큰을 요청할 때 사용할 파라미터를 생성한다.
+	 * @param client - OAuth 클라이언트 설정
+	 * @param decodedCode - 디코딩된 인증 코드
+	 * @return 생성된 파라미터 맵
+	 */
+	private MultiValueMap<String, String> createTokenRequestParams(OAuth2Properties.Client client, String decodedCode) {
+	    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+	    params.add("client_id", client.getClientId());
+	    params.add("client_secret", client.getClientSecret());
+	    params.add("code", decodedCode);
+	    params.add("grant_type", "authorization_code");
+	    params.add("redirect_uri", client.getRedirectUri());
+	    return params;
+	}
+	
+	/**
+	 * 토큰 URI로 액세스 토큰을 요청한다.
+	 * @param tokenUri - 토큰 요청 URI
+	 * @param headers - HTTP 요청 헤더
+	 * @param params - HTTP 요청 파라미터
+	 * @return responseEntity - 토큰 요청에 대한 응답
+	 */
+	private ResponseEntity<Map> sendTokenRequest(String tokenUri, HttpHeaders headers, MultiValueMap<String, String> params) {
+	    RestTemplate restTemplate = new RestTemplate();
+	    HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+	    return restTemplate.postForEntity(tokenUri, requestEntity, Map.class);
+	}
+	
+	/**
+	 * 응답 엔티티에서 액세스 토큰을 추출한다.
+	 * @param responseEntity - 액세스 토큰 요청 응답
+	 * @return accessToken - 응답에서 추출한 액세스 토큰
+	 */
+	private String extractAccessToken(ResponseEntity<Map> responseEntity) {
+	    if (!responseEntity.getStatusCode().is2xxSuccessful() || responseEntity.getBody() == null) {
+	        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 정보를 가져올 수 없음");
+	    }
+	    return (String) responseEntity.getBody().get("access_token");
+	}
+	
+	/**
+	 * OAuth provider에서 사용자 정보를 가져온다.
+	 * @param accessToken - OAuth 액세스 토큰
+	 * @param platformType - OAuth 플랫폼 유형
+	 * @return 사용자 정보를 담고 있는 JsonNode 객체
+	 */
+	private JsonNode generateOAuthUserNode(String accessToken, PlatformTypeEnum platformType) {
+		// 설정 가져오기
+		OAuth2Properties.Client client = getClientProperties(platformType);
+		
+		// HTTP 요청 헤더 생성
+		HttpHeaders headers = createAuthorizationHeaders(accessToken);
+		
+		// 사용자 정보 요청
+		ResponseEntity<JsonNode> responseEntity = fetchUserInfoFromProvider(client.getUserInfoRequestUri(), headers);
+		
+		// 응답 검증 및 사용자 정보 반환
+		return extractUserInfo(responseEntity);
+	}
+	
+	/**
+	 * 액세스 토큰을 사용하여 사용자 정보를 요청할 때 사용하는 헤더를 생성한다.
+	 * @param accessToken - OAuth 액세스 토큰
+	 * @return 생성된 HTTP 요청 헤더
+	 */
+	private HttpHeaders createAuthorizationHeaders(String accessToken) {
+	    HttpHeaders headers = new HttpHeaders();
+	    headers.add("Authorization", "Bearer " + accessToken);
+	    return headers;
+	}
+	
+	/**
+	 * 사용자 정보 URI로 사용자 정보를 요청한다.
+	 * @param userInfoUri - 사용자 정보 요청 URI
+	 * @param headers - HTTP 요청 헤더
+	 * @return 사용자 정보에 대한 응답
+	 */
+	private ResponseEntity<JsonNode> fetchUserInfoFromProvider(String userInfoUri, HttpHeaders headers) {
+	    RestTemplate restTemplate = new RestTemplate();
+	    return restTemplate.exchange(userInfoUri, HttpMethod.GET, new HttpEntity<>(headers), JsonNode.class);
+	}
+	
+	/**
+	 * 응답 엔티티에서 사용자 정보를 추출한다.
+	 * @param responseEntity - 사용자 정보 요청 응답
+	 * @return 사용자 정보를 담은 JsonNode 객체
+	 */
+	private JsonNode extractUserInfo(ResponseEntity<JsonNode> responseEntity) {
+	    if (!responseEntity.getStatusCode().is2xxSuccessful() || responseEntity.getBody() == null) {
+	        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 정보를 가져올 수 없음");
+	    }
+	    return responseEntity.getBody();
+	}
+	
+	/**
+	 * OAuth provider에 따라 사용자 정보를 추출하여 OAuthUserInfo 객체를 생성한다.
+	 * @param oAuthUserNode - 사용자 정보를 담고 있는 JsonNode 객체
+	 * @param provider - OAuth 플랫폼 유형 (Kakao, Google 등)
+	 * @return OAuthUserInfo - 사용자 정보 객체
+	 */
+	private OAuthUserInfo fetchOAuthUserInfo(JsonNode oAuthUserNode, PlatformTypeEnum provider) {
+	    switch (provider) {
+	        case KAKAO:
+	            return extractKakaoUserInfo(oAuthUserNode);
+	        case GOOGLE:
+	            return extractGoogleUserInfo(oAuthUserNode);
+	        default:
+	            throw new IllegalArgumentException("지원하지 않는 플랫폼 유형입니다: " + provider);
+	    }
+	}
+
+	/**
+	 * Kakao 플랫폼으로부터 사용자 정보를 추출한다.
+	 * @param oAuthUserNode - Kakao에서 제공한 사용자 정보가 담긴 JsonNode 객체
+	 * @return OAuthUserInfo - Kakao 사용자 정보 객체
+	 */
+	private OAuthUserInfo extractKakaoUserInfo(JsonNode oAuthUserNode) {
+	    String key = oAuthUserNode.get("id").asText();
+	    String name = extractJsonNodeText(oAuthUserNode, "properties", "nickname");
+	    log.info("Kakao User Info - key: {}, name: {}", key, name);
+	    return new OAuthUserInfo(key, null, name, PlatformTypeEnum.KAKAO);
+	}
+
+	/**
+	 * Google 플랫폼으로부터 사용자 정보를 추출한다.
+	 * @param oAuthUserNode - Google에서 제공한 사용자 정보가 담긴 JsonNode 객체
+	 * @return OAuthUserInfo - Google 사용자 정보 객체
+	 */
+	private OAuthUserInfo extractGoogleUserInfo(JsonNode oAuthUserNode) {
+	    String key = oAuthUserNode.get("sub").asText();
+	    String email = oAuthUserNode.get("email").asText();
+	    String name = oAuthUserNode.get("name").asText();
+	    log.info("Google User Info - key: {}, email: {}, name: {}", key, email, name);
+	    return new OAuthUserInfo(key, email, name, PlatformTypeEnum.GOOGLE);
+	}
+
+	/**
+	 * 주어진 부모 노드와 자식 노드 이름으로 JsonNode에서 텍스트 값을 추출한다.
+	 * @param parentNode - 부모 JsonNode 객체
+	 * @param childNodeName - 자식 노드 이름
+	 * @return 추출된 텍스트 값
+	 */
+	private String extractJsonNodeText(JsonNode parentNode, String... childNodeName) {
+	    JsonNode currentNode = parentNode;
+	    for (String nodeName : childNodeName) {
+	        if (currentNode == null || !currentNode.has(nodeName)) {
+	            throw new IllegalArgumentException("해당 노드를 찾을 수 없습니다: " + nodeName);
+	        }
+	        currentNode = currentNode.get(nodeName);
+	    }
+	    return currentNode.asText();
+	}
+}

--- a/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
@@ -122,6 +122,7 @@ public class UserServiceImpl implements UserService {
 	 * @return 생성된 파라미터 맵
 	 */
 	private MultiValueMap<String, String> createTokenRequestParams(OAuth2Properties.Client client, String decodedCode) {
+		log.info("{}", client);
 	    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 	    params.add("client_id", client.getClientId());
 	    params.add("client_secret", client.getClientSecret());
@@ -233,10 +234,10 @@ public class UserServiceImpl implements UserService {
 	 * @return OAuthUserInfo - Kakao 사용자 정보 객체
 	 */
 	private OAuthUserInfo extractKakaoUserInfo(JsonNode oAuthUserNode) {
-	    String key = oAuthUserNode.get("id").asText();
+	    String socialKey = oAuthUserNode.get("id").asText();
 	    String name = extractJsonNodeText(oAuthUserNode, "properties", "nickname");
-	    log.info("Kakao User Info - key: {}, name: {}", key, name);
-	    return new OAuthUserInfo(key, null, name, PlatformTypeEnum.KAKAO);
+	    log.info("Kakao User Info - socialKey: {}, name: {}", socialKey, name);
+	    return new OAuthUserInfo(socialKey, null, name, PlatformTypeEnum.KAKAO);
 	}
 
 	/**
@@ -245,11 +246,11 @@ public class UserServiceImpl implements UserService {
 	 * @return OAuthUserInfo - Google 사용자 정보 객체
 	 */
 	private OAuthUserInfo extractGoogleUserInfo(JsonNode oAuthUserNode) {
-	    String key = oAuthUserNode.get("sub").asText();
+	    String socialKey = oAuthUserNode.get("sub").asText();
 	    String email = oAuthUserNode.get("email").asText();
 	    String name = oAuthUserNode.get("name").asText();
-	    log.info("Google User Info - key: {}, email: {}, name: {}", key, email, name);
-	    return new OAuthUserInfo(key, email, name, PlatformTypeEnum.GOOGLE);
+	    log.info("Google User Info - socialKey: {}, email: {}, name: {}", socialKey, email, name);
+	    return new OAuthUserInfo(socialKey, email, name, PlatformTypeEnum.GOOGLE);
 	}
 
 	/**

--- a/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/UserServiceImpl.java
@@ -234,6 +234,7 @@ public class UserServiceImpl implements UserService {
 	 * @return OAuthUserInfo - Kakao 사용자 정보 객체
 	 */
 	private OAuthUserInfo extractKakaoUserInfo(JsonNode oAuthUserNode) {
+		log.info("Kakao User Info: {}", oAuthUserNode);
 	    String socialKey = oAuthUserNode.get("id").asText();
 	    String name = extractJsonNodeText(oAuthUserNode, "properties", "nickname");
 	    log.info("Kakao User Info - socialKey: {}, name: {}", socialKey, name);

--- a/costcook/src/main/java/com/costcook/util/OAuth2Properties.java
+++ b/costcook/src/main/java/com/costcook/util/OAuth2Properties.java
@@ -1,0 +1,24 @@
+package com.costcook.util;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "oauth2")
+public class OAuth2Properties {
+	private Map<String, Client> clients;
+	
+	@Data
+	public static class Client {
+		private String clientId;
+		private String clientSecret;
+		private String redirectUri;
+		private String tokenUri;
+		private String userInfoRequestUri;
+	}
+}

--- a/costcook/src/main/java/com/costcook/util/TokenUtils.java
+++ b/costcook/src/main/java/com/costcook/util/TokenUtils.java
@@ -1,0 +1,68 @@
+package com.costcook.util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.costcook.domain.response.SignUpOrLoginResponse;
+import com.costcook.entity.User;
+import com.costcook.security.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenUtils {
+    private final JwtProvider jwtProvider;
+    
+    // 사용자 정보를 기반으로 액세스 토큰과 리프레시 토큰을 생성
+    public Map<String, String> generateToken(User user) {
+        log.info(user.toString());
+        String accessToken = jwtProvider.generateAccessToken(user);
+        String refreshToken = jwtProvider.generateRefreshToken(user);
+        log.info("{}, {}", accessToken, refreshToken);
+        
+        // 생성된 토큰을 Map에 담아 반환
+        Map<String, String> tokenMap = new HashMap<>();
+        tokenMap.put("accessToken", accessToken);
+        tokenMap.put("refreshToken", refreshToken);        
+        return tokenMap;
+    }
+    
+    // JSON 형식의 응답을 전송
+    public void writeResponse(HttpServletResponse response, SignUpOrLoginResponse signUpOrLoginResponse) throws IOException {        
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(signUpOrLoginResponse);
+        
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
+    }
+    
+    // 쿠키 설정을 위한 기본 메소드
+    public void setCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+    
+    // 리프레시 토큰을 쿠키에 설정하는 메소드
+    public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        setCookie(response, "refreshToken", refreshToken, 1 * 24 * 60 * 60); // 1일 유효기간
+    }
+
+    // 액세스 토큰을 쿠키에 설정하는 메소드
+    public void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
+        setCookie(response, "accessToken", accessToken, 30 * 60); // 30분 유효기간
+    }
+}


### PR DESCRIPTION
## 작업 내용 (What)
1. 클라이언트 접근 가능하도록 CORS 설정
2. Provider(kakao, google) 로부터 정보 추출하는 API 예외 처리 로직 추가.
3. 회원가입 후 자동 로그인 처리하는 API 개발

## 작업 이유 (Why)
1. 프론트엔드와 API 연동을 위해 설정해줘야 합니다.
2. 우리 서비스 회원가입 여부와 상관없이 기본적으로 kakao 로부터 제공받는 데이터 중 email 은 null 이기 때문에 이를 통해 우리 서비스 회원가입 여부 파악이 어렵다. 따라서 socialKey, provider 를 제공받고 이후에 추가적으로 우리 DB 테이블에 접근해서 가입 여부를 확인 후 이미 가입된 회원인 경우 email 값을 업데이트해주는 로직이 필요하다.
3. 새로운 기능 추가

## 변경 사항 (Changes)
- [ ] Provider(kakao, google) 로부터 정보 추출하는 API 예외 처리 로직 추가.
- [ ] User 정보를 토대로 액세스 토큰, 리프레시 토큰 발급 로직 구현
- [ ] 발급된 액세스 토큰, 리프레시 토큰을 각각 응답 헤더 set-cookie 로 설정하는 로직 구현
- [ ] 리프레시 토큰 발급받은 후 users 테이블에 업데이트하는 로직 구현
- [ ] 동일한 이메일로 이미 가입된 계정이지만 다른 provider 로 가입하는 경우를 고려하여 로직 구현

## 테스트 결과 (Test Result)
구글 계정으로 신규 회원가입/로그인하는 경우,
정상적으로 발급된 accessToken, refreshToken 이 브라우저 쿠키 탭에 저장되어 있음.
![image](https://github.com/user-attachments/assets/5e205ca9-0e0b-4f8a-b77d-b281aecbab56)

정상적으로 users 테이블에 저장됨.
![image](https://github.com/user-attachments/assets/c2a40f59-9843-462b-959c-bcb1da49d9cb)

정상적으로 social_accounts 테이블에 저장됨.
![image](https://github.com/user-attachments/assets/cbde08ec-e477-4472-85e2-fa1289141122)

동일한 이메일로 카카오 계정으로 신규 회원가입/로그인하는 경우,
인증번호가 담긴 이메일 인증 발송 요청
![image](https://github.com/user-attachments/assets/0986e572-e8f4-451c-8f3f-c854788659de)

정상적으로 인증번호가 email_verifications 테이블에 저장됨.
![image](https://github.com/user-attachments/assets/298131d1-86ca-481f-9087-a70a7b27401b)

인증번호 입력 후 인증번호 확인/회원가입 및 로그인 요청
![image](https://github.com/user-attachments/assets/0c05c156-3232-4dde-af41-7d987b26433c)

정상적으로 발급된 accessToken, refreshToken 이 브라우저 쿠키 탭에 저장되어 있음.
![image](https://github.com/user-attachments/assets/bc2436ca-76b4-4689-a945-b3516714761b)

정상적으로 social_accounts 테이블에 저장됨.
![image](https://github.com/user-attachments/assets/56168405-6de3-4356-8dda-f71cebb1ac7d)

 

