### PR TITLE
fix:RecipeResponse > thumbnailUrl누락 수정

### DIFF
--- a/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
@@ -13,7 +13,7 @@ public class RecipeResponse {
 
 	private Long id, categoryId;
 	private int rcpSno;
-	private String title, description, createdAt, updatedAt;
+	private String title, description, thumbnailUrl, createdAt, updatedAt;
 	private int servings, price, viewCount, bookmarkCount, commentCount;
 	private double avgRatings;
 
@@ -33,6 +33,7 @@ public class RecipeResponse {
 				.bookmarkCount(recipe.getBookmarkCount())
 				.commentCount(recipe.getCommentCount())
 				.avgRatings(recipe.getAvgRatings())
+				.thumbnailUrl(recipe.getThumbnailUrl())
 				.build();
 	}
 	


### PR DESCRIPTION
## 작업 내용 (What)
RecipeResponse에서 thumbnailUrl 누락된 것을 추가

## 작업 이유 (Why)
이미지 출력

## 변경 사항 (Changes)
RecipeResponse.java에 코드 추가

> 	RecipeResponse.builder()
                        .thumbnailUrl(recipe.getThumbnailUrl())


## 테스트 결과 (Test Result)
웹 페이지 콘솔 로그에서 thumbnailUrl 출력 확인


## 추가 사항 (Additional Info)
백엔드API -> 프론트엔드 연동 작업중
