### PR TITLE
Feat: 회원가입 및 로그인 응답 데이터 추가

### DIFF
--- a/costcook/src/main/java/com/costcook/controller/UserController.java
+++ b/costcook/src/main/java/com/costcook/controller/UserController.java
@@ -48,14 +48,20 @@ public class UserController {
         @AuthenticationPrincipal User userDetails, // 사용자 정보 가져오기,
         @ModelAttribute UserUpdateRequest requestDTO
     ) {
-        log.info("내 정보 업데이트 API 호출");
-        log.info("내 정보: {}", userDetails.toString());
-        log.info("요청 본문 정보: {}", requestDTO.toString());
-
-        // 사용자 정보 업데이트 로직 서비스에 위임
-        userService.updateUserInfo(userDetails, requestDTO);
-
-        // 성공 응답 반환
-        return ResponseEntity.ok("내 정보가 성공적으로 업데이트되었습니다.");
+        try {
+            log.info("내 정보 업데이트 API 호출");
+            log.info("내 정보: {}", userDetails.toString());
+            log.info("요청 본문 정보: {}", requestDTO.toString());
+    
+            // 사용자 정보 업데이트 로직 서비스에 위임
+            userService.updateUserInfo(userDetails, requestDTO);
+    
+            // 성공 응답 반환
+            return ResponseEntity.ok("내 정보가 성공적으로 업데이트되었습니다.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.error("{}", e.getMessage());
+            throw e;
+        }
     }
 }

--- a/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/SignUpOrLoginResponse.java
@@ -11,6 +11,7 @@ public class SignUpOrLoginResponse {
     private String message;
     private String accessToken;
     private boolean isNewUser;
+    private boolean isUserProfileUpdated;
 
     public SignUpOrLoginResponse(String message) {
         this.message = message;

--- a/costcook/src/main/java/com/costcook/entity/DislikedIngredient.java
+++ b/costcook/src/main/java/com/costcook/entity/DislikedIngredient.java
@@ -8,8 +8,6 @@ import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 
-import com.costcook.domain.BaseTaste;
-
 @Entity
 @Table(name = "disliked_ingredients")
 @Data

--- a/costcook/src/main/java/com/costcook/entity/PreferredIngredient.java
+++ b/costcook/src/main/java/com/costcook/entity/PreferredIngredient.java
@@ -8,8 +8,6 @@ import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 
-import com.costcook.domain.BaseTaste;
-
 @Entity
 @Table(name = "preferred_ingredients")
 @Data

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.costcook.service.impl;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -10,10 +11,14 @@ import org.springframework.stereotype.Service;
 import com.costcook.domain.PlatformTypeEnum;
 import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.response.SignUpOrLoginResponse;
+import com.costcook.entity.DislikedIngredient;
+import com.costcook.entity.PreferredIngredient;
 import com.costcook.entity.SocialAccount;
 import com.costcook.entity.User;
 import com.costcook.exceptions.InvalidProviderException;
 import com.costcook.exceptions.MissingFieldException;
+import com.costcook.repository.DislikedIngredientRepository;
+import com.costcook.repository.PreferredIngredientRepository;
 import com.costcook.repository.SocialAccountRepository;
 import com.costcook.repository.UserRepository;
 import com.costcook.security.JwtProvider;
@@ -21,6 +26,7 @@ import com.costcook.service.AuthService;
 import com.costcook.util.TokenUtils;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +37,8 @@ public class AuthServiceImpl implements AuthService {
     private final UserDetailsService userDetailsService;
     private final UserRepository userRepository;
     private final SocialAccountRepository socialAccountRepository;
+    private final PreferredIngredientRepository preferredIngredientRepository;
+    private final DislikedIngredientRepository dislikedIngredientRepository;
     private final TokenUtils tokenUtils;
     private final JwtProvider jwtProvider;
     
@@ -58,52 +66,64 @@ public class AuthServiceImpl implements AuthService {
         return Optional.empty(); // 사용자를 찾지 못한 경우
     }
 
+    @Transactional
     @Override
     public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response) {
-        // 1. Request DTO 유효성 검증
-        validateSignUpOrLoginRequest(request);
+        try {
+            // 1. Request DTO 유효성 검증
+            validateSignUpOrLoginRequest(request);
+    
+            // 2. email 필드를 기준으로 회원 가입 여부 확인
+            // 이 부분에서 에러 발생한다고 예상됨. 원인: preferredIngredients 필드 및 dislikedIngredients 필드에 대해 즉시 로딩 지원으로 인해서.
+            User user = userRepository.findByEmail(request.getEmail())
+                    .orElseGet(() -> registerNewUser(request));
+            // 사용자 프로필 업데이트 여부: 닉네임, 프로필 이미지, 기피 재료, 선호 재료 중 하나라도 설정되어 있지 않다면 false
+            List<DislikedIngredient> dislikedIngredients = dislikedIngredientRepository.findByUserId(user.getId());
+            List<PreferredIngredient> preferredIngredients = preferredIngredientRepository.findByUserId(user.getId());
+            boolean isUserProfileUpdated = user.getNickname() != null && user.getProfileUrl() != null && !dislikedIngredients.isEmpty() && !preferredIngredients.isEmpty();
+    
+            // 2-2. email 을 기준으로 이미 회원가입한 회원이지만, social_accounts 테이블 조회(provider, socialKey) 없는 경우 registerNewUser(request) 호출 필요.
+            log.info("findBySocialKeyAndProvider 호출");        
+            Optional<SocialAccount> socialAccount = socialAccountRepository.findBySocialKeyAndProvider(request.getSocialKey(), PlatformTypeEnum.fromString(request.getProvider()));
+            log.info("{}", socialAccount.toString());        
+            if (!socialAccount.isPresent() && request.getProvider() != null && request.getSocialKey() != null) {
+                // 소셜 계정 정보가 없다면 카카오 계정 정보를 등록
+                registerSocialAccount(user, request.getProvider(), request.getSocialKey());
+                log.info("소셜 계정 정보가 등록되었습니다: {} - {}", request.getProvider(), request.getSocialKey());
+            }
+    
+    
+            // 3. 액세스 토큰, 리프레시 토큰 발급
+            Map<String, String> tokenMap = tokenUtils.generateToken(user);
+            String accessToken = tokenMap.get("accessToken");
+            String refreshToken = tokenMap.get("refreshToken");
+            log.info("새로 발급된 액세스 토큰: {}", accessToken);
+            log.info("새로 발급된 리프레시 토큰: {}", refreshToken);
+            
+            // 4. 발급된 리프레시 토큰 사용자 테이블에 저장
+            user.setRefreshToken(refreshToken);
+            userRepository.save(user);
+            
+            // 5. 쿠키에 생성된 리프레시 토큰과 액세스 토큰을 담아 응답
+            tokenUtils.setRefreshTokenCookie(response, refreshToken);
+            tokenUtils.setAccessTokenCookie(response, accessToken);
+            
+            // SignUpOrLoginResponse 객체 생성
+            boolean isNewUser = user.getCreatedAt().isAfter(LocalDateTime.now().minusMinutes(1)); // 1분 이내에 생성된 경우 신규 사용자로 간주
+            SignUpOrLoginResponse signUpOrLoginResponse = SignUpOrLoginResponse.builder()
+                    .message(isNewUser ? "회원가입 후 로그인이 완료되었습니다." : "로그인에 성공했습니다.")
+                    .accessToken(accessToken)
+                    .isNewUser(isNewUser)
+                    .isUserProfileUpdated(isUserProfileUpdated)
+                    .build();
+            
+            return signUpOrLoginResponse;
 
-        // 2. email 필드를 기준으로 회원 가입 여부 확인
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseGet(() -> registerNewUser(request));
-
-        log.info("새로 가입한 회원 정보: {}", user);
-
-        // 2-2. email 을 기준으로 이미 회원가입한 회원이지만, social_accounts 테이블 조회(provider, socialKey) 없는 경우 registerNewUser(request) 호출 필요.
-        log.info("findBySocialKeyAndProvider 호출");        
-        Optional<SocialAccount> socialAccount = socialAccountRepository.findBySocialKeyAndProvider(request.getSocialKey(), PlatformTypeEnum.fromString(request.getProvider()));
-        log.info("{}", socialAccount.toString());        
-        if (!socialAccount.isPresent() && request.getProvider() != null && request.getSocialKey() != null) {
-            // 소셜 계정 정보가 없다면 카카오 계정 정보를 등록
-            registerSocialAccount(user, request.getProvider(), request.getSocialKey());
-            log.info("소셜 계정 정보가 등록되었습니다: {} - {}", request.getProvider(), request.getSocialKey());
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.error("{}",e.getMessage());
+            throw e;
         }
-
-
-        // 3. 액세스 토큰, 리프레시 토큰 발급
-        Map<String, String> tokenMap = tokenUtils.generateToken(user);
-        String accessToken = tokenMap.get("accessToken");
-        String refreshToken = tokenMap.get("refreshToken");
-        log.info("새로 발급된 액세스 토큰: {}", accessToken);
-        log.info("새로 발급된 리프레시 토큰: {}", refreshToken);
-        
-        // 4. 발급된 리프레시 토큰 사용자 테이블에 저장
-        user.setRefreshToken(refreshToken);
-        userRepository.save(user);
-        
-        // 5. 쿠키에 생성된 리프레시 토큰과 액세스 토큰을 담아 응답
-        tokenUtils.setRefreshTokenCookie(response, refreshToken);
-        tokenUtils.setAccessTokenCookie(response, accessToken);
-        
-        // SignUpOrLoginResponse 객체 생성
-        boolean isNewUser = user.getCreatedAt().isAfter(LocalDateTime.now().minusMinutes(1)); // 1분 이내에 생성된 경우 신규 사용자로 간주
-        SignUpOrLoginResponse signUpOrLoginResponse = SignUpOrLoginResponse.builder()
-                .message(isNewUser ? "회원가입 후 로그인이 완료되었습니다." : "로그인에 성공했습니다.")
-                .accessToken(accessToken)
-                .isNewUser(isNewUser)
-                .build();
-        
-        return signUpOrLoginResponse;
     }
 
     // SignUpOrLoginRequest의 필수 필드를 검증


### PR DESCRIPTION
## 작업 내용 (What)
회원가입 및 로그인 응답 데이터(userProfileUpdated) 추가 및 그에 따른 로직 추가

## 작업 이유 (Why)
프론트엔드에서 해당 데이터에 따라 사용자 프로필 업데이트 페이지 접근 여부 처리

## 변경 사항 (Changes)
- [ ] 회원가입 및 로그인 응답 데이터(userProfileUpdated) 추가
- [ ] 현재 로그인한 사용자 id 를 기준으로 선호 재료(preferredIngredients) 및 기피 재료(dislikedIngredients) 조회 로직 추가
