### PR TITLE
Feat: 로그아웃 API 구현

### DIFF
--- a/costcook/src/main/java/com/costcook/controller/AuthController.java
+++ b/costcook/src/main/java/com/costcook/controller/AuthController.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import org.apache.catalina.connector.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,10 +18,11 @@ import com.costcook.service.AuthService;
 import com.costcook.domain.request.EmailRequest;
 import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.request.VerificationRequest;
+import com.costcook.domain.response.DefaultSuccessResponse;
 import com.costcook.domain.response.SignUpOrLoginResponse;
 import com.costcook.domain.response.VerifyCodeResponse;
+import com.costcook.entity.User;
 import com.costcook.exceptions.ErrorResponse;
-import com.costcook.security.JwtProperties;
 import com.costcook.service.EmailService;
 import com.costcook.util.EmailUtil;
 import com.costcook.util.TokenUtils;
@@ -103,4 +105,21 @@ public class AuthController {
 					.body(new ErrorResponse(e.getMessage()));
 		}
 	}	
+
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(
+		@AuthenticationPrincipal User currentUser, // 현재 로그인한 사용자 정보 가져오기,
+		@CookieValue(value = "refreshToken", required = false) String refreshToken,
+		HttpServletResponse response
+	) {
+		log.info("로그아웃 API 호출");
+
+		try {
+			// user 조회해서 refreshToken 컬럼 null 처리.
+            String message = authService.logout(currentUser, refreshToken, response);
+            return ResponseEntity.ok().body(new DefaultSuccessResponse(message));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(e.getMessage()));
+        }
+	}
 }

--- a/costcook/src/main/java/com/costcook/domain/response/DefaultSuccessResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/DefaultSuccessResponse.java
@@ -1,0 +1,10 @@
+package com.costcook.domain.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DefaultSuccessResponse {
+    private String message; // 에러 메시지
+}

--- a/costcook/src/main/java/com/costcook/service/AuthService.java
+++ b/costcook/src/main/java/com/costcook/service/AuthService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import com.costcook.domain.PlatformTypeEnum;
 import com.costcook.domain.request.SignUpOrLoginRequest;
 import com.costcook.domain.response.SignUpOrLoginResponse;
+import com.costcook.entity.User;
 
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -12,4 +13,5 @@ public interface AuthService {
 	public Optional<String> getEmailFromSocialAccount(String socialKey, PlatformTypeEnum provider);
 	public SignUpOrLoginResponse signUpOrLogin(SignUpOrLoginRequest request, HttpServletResponse response);
 	public String refreshAccessToken(String refreshToken);
+	public String logout(User user, String refreshToken, HttpServletResponse response);
 }

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -199,4 +199,18 @@ public class AuthServiceImpl implements AuthService {
         // 4. 새로운 액세스 토큰 반환
         return newAccessToken;
     }
+
+    @Override
+    public String logout(User user, String refreshToken, HttpServletResponse response) {
+        if (refreshToken != null) {
+            // 리프레시 토큰을 null로 설정
+            user.setRefreshToken(null);
+            userRepository.save(user); // 사용자 정보를 업데이트하여 DB에 저장
+        }
+
+        // 리프레시 토큰 쿠키 제거
+        tokenUtils.removeRefreshTokenCookie(response);
+
+        return "로그아웃이 성공적으로 처리되었습니다.";
+    }
 }

--- a/costcook/src/main/java/com/costcook/util/TokenUtils.java
+++ b/costcook/src/main/java/com/costcook/util/TokenUtils.java
@@ -65,4 +65,9 @@ public class TokenUtils {
     public void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
         setCookie(response, "accessToken", accessToken, 30 * 60); // 30분 유효기간
     }
+
+    // 리프레시 토큰을 쿠키에서 제거하는 메소드
+    public void removeRefreshTokenCookie(HttpServletResponse response) {
+        setCookie(response, "refreshToken", "", 0); // 유효기간을 0으로 설정하여 쿠키 제거
+    }
 }


### PR DESCRIPTION
### 작업 내용 (What)
로그아웃 기능을 위한 API 엔드포인트 및 비즈니스 로직을 구현했습니다.

API 엔드포인트: /api/auth/logout 추가
세션 종료: 사용자의 DB에서 refreshToken 값을 null 처리하여 로그아웃 처리
응답 메시지: 로그아웃 성공 시 적절한 메시지 반환
작업 이유 (Why)
사용자가 로그아웃할 수 있는 기능이 필요하여, 보안 및 사용자 경험을 개선하기 위해 로그아웃 API를 추가했습니다.

사용자 세션 관리의 일환으로 로그아웃 기능 제공
보안 강화를 위해 사용자가 명시적으로 로그아웃할 수 있도록 함

### 변경 사항 (Changes)
코드 변경 사항에 대해 구체적으로 설명합니다.

 API 엔드포인트 추가: /api/auth/logout
 인증 로직 수정: DB에서 refreshToken 값을 null 처리하여 로그아웃 처리
 쿠키 삭제: 클라이언트의 refreshToken 쿠키 제거