### PR TITLE
Feat: 레시피 검색 API 구현

### DIFF
--- a/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
+++ b/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
@@ -46,7 +46,6 @@ public class CommonRecipeController {
 		return ResponseEntity.ok(response);
 	}
 	
-	
     // 레시피별 상세보기
 	@GetMapping("/{recipeId}")
 	public ResponseEntity<RecipeDetailResponse> getIngredientsByRecipeId(@PathVariable("recipeId") Long id) {

--- a/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
+++ b/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
@@ -45,6 +45,18 @@ public class CommonRecipeController {
 		RecipeListResponse response = recipeService.getRecipes(page, size, sort, order);
 		return ResponseEntity.ok(response);
 	}
+
+	// 레시피 검색
+	@GetMapping("/search")
+	public ResponseEntity<RecipeListResponse> searchRecipes(
+		@RequestParam(value = "keyword", required = false) String keyword,
+		@RequestParam(value = "page", defaultValue = "0") int page
+	) {
+		log.info("레시피 검색 API 호출");
+		RecipeListResponse response = recipeService.searchRecipes(keyword, page);
+		return ResponseEntity.ok(response);
+	}
+	
 	
     // 레시피별 상세보기
 	@GetMapping("/{recipeId}")

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
@@ -2,6 +2,7 @@ package com.costcook.domain.response;
 
 import lombok.Builder;
 import lombok.Data;
+
 import java.util.List;
 
 @Data

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
@@ -1,12 +1,16 @@
 package com.costcook.domain.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class RecipeListResponse {
     private int page; // 현재 페이지 번호
     private int size; // 한 페이지에 포함된 레시피 수

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
@@ -22,7 +22,6 @@ public class RecipeResponse {
 	// Recipe -> response 변환
 	// 전체 목록
 	public static RecipeResponse toDTO(Recipe recipe, double avgRatings, int reviewCount, Long totalPrice) {		
-		
 		// 평점 소수점 첫째자리까지 반올림
 		double roundedAvgRatings = Math.round(avgRatings * 10) / 10.0;
 		
@@ -32,18 +31,14 @@ public class RecipeResponse {
 				.rcpSno(recipe.getRcpSno())
 				.title(recipe.getTitle())
 				.description(recipe.getDescription())
-        .thumbnailUrl(recipe.getThumbnailUrl())
+        		.thumbnailUrl(recipe.getThumbnailUrl())
 				.createdAt(recipe.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
 				.updatedAt(recipe.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
 				.servings(recipe.getServings())
 				.price(totalPrice.intValue())
 				.viewCount(recipe.getViewCount())
-				// .favoriteCount(recipe.getFavoriteCount())
 				.reviewCount(reviewCount)
 				.avgRatings(roundedAvgRatings)
-				.thumbnailUrl(recipe.getThumbnailUrl())
 				.build();
 	}
-	
-	
 }

--- a/costcook/src/main/java/com/costcook/exceptions/GlobalExceptionHandler.java
+++ b/costcook/src/main/java/com/costcook/exceptions/GlobalExceptionHandler.java
@@ -34,6 +34,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
+        e.printStackTrace();
         ErrorResponse errorResponse = new ErrorResponse("서버 에러가 발생했습니다.");
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }

--- a/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
@@ -38,6 +38,4 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
 	@Query("SELECT SUM(i.price * ri.quantity) FROM Recipe recipe LEFT JOIN RecipeIngredient ri ON ri.recipe.id = recipe.id LEFT JOIN Ingredient i on ri.ingredient.id = i.id WHERE recipe.id = :id")
 	Long getTotalPrice(@Param("id") Long id);
-	
-	
 }

--- a/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/RecipeRepository.java
@@ -38,4 +38,11 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
 	@Query("SELECT SUM(i.price * ri.quantity) FROM Recipe recipe LEFT JOIN RecipeIngredient ri ON ri.recipe.id = recipe.id LEFT JOIN Ingredient i on ri.ingredient.id = i.id WHERE recipe.id = :id")
 	Long getTotalPrice(@Param("id") Long id);
+
+	// 레시피 검색(검색 대상: 레시피 이름, 레시피 구성 재료명)
+	@Query("SELECT DISTINCT r FROM Recipe r " +
+	"LEFT JOIN RecipeIngredient ri ON r.id = ri.recipe.id " +
+	"LEFT JOIN Ingredient i ON ri.ingredient.id = i.id " +
+	"WHERE r.title LIKE %:keyword% OR i.name LIKE %:keyword%")
+	Page<Recipe> findByTitleOrIngredientNameContaining(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/costcook/src/main/java/com/costcook/service/RecipeService.java
+++ b/costcook/src/main/java/com/costcook/service/RecipeService.java
@@ -1,7 +1,5 @@
 package com.costcook.service;
 
-import java.util.List;
-
 import com.costcook.domain.response.RecipeListResponse;
 import com.costcook.domain.response.RecipeResponse;
 

--- a/costcook/src/main/java/com/costcook/service/RecipeService.java
+++ b/costcook/src/main/java/com/costcook/service/RecipeService.java
@@ -13,4 +13,6 @@ public interface RecipeService {
 	
 	// 레시피 ID를 통해 레시피 가져오기 -> 상세보기
 	RecipeResponse getRecipeById(Long id);
+
+	RecipeListResponse searchRecipes(String keyword, int page);
 }

--- a/costcook/src/main/java/com/costcook/service/ReviewService.java
+++ b/costcook/src/main/java/com/costcook/service/ReviewService.java
@@ -19,8 +19,6 @@ public interface ReviewService {
 
 	ReviewListResponse getReviewList(Long recipeId, int page, int size);
 
-	List<ReviewResponse> getReviewList(Long recipeId);
-
 	ReviewListResponse getReviewListByUserWithPagination(User user, int page);
 
 }

--- a/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
@@ -1,7 +1,6 @@
 package com.costcook.service.impl;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -102,5 +101,55 @@ public class RecipeServiceImpl implements RecipeService {
 		
 		// 리뷰 개수 가져오기
 		return RecipeResponse.toDTO(recipe, averageScore, commentCount, totalPrice);
+	}
+
+	@Override
+	public RecipeListResponse searchRecipes(String keyword, int page) {
+		try {
+			// 예외 처리: keyword가 null이거나 빈 문자열 또는 공백만 있는 경우
+			if (keyword == null || keyword.trim().isEmpty()) {
+				throw new IllegalArgumentException("검색어를 입력해 주세요.");
+			}
+
+			// 기본 페이지 크기 설정
+			int size = 9; 
+			// 최소 1 이상의 값을 보장
+			int validPage = Math.max(page, 1) - 1; 
+	
+			// 페이지네이션 설정
+			Pageable pageable = PageRequest.of(validPage, size);
+		
+			// 공백을 제거한 후 검색을 수행
+			String trimmedKeyword = keyword.trim();
+		
+            // 새로운 요구사항: keyword, page 로 검색된 레시피 목록 중에서 레시피를 구성하는 재료명까지도 검색 대상에 포함시키고 싶어.
+
+			// 키워드를 포함하는 레시피 검색 로직
+			Page<Recipe> recipePage = recipeRepository.findByTitleOrIngredientNameContaining(trimmedKeyword, pageable);
+			
+			return RecipeListResponse.builder()
+				.page(validPage + 1)
+				.size(recipePage.getNumberOfElements())
+				.totalPages(recipePage.getTotalPages())
+				.totalRecipes(recipePage.getTotalElements())
+				.recipes(
+					recipePage.getContent().stream()
+					.map(recipe -> {
+						ReviewStatsDTO stats = recipeRepository.findCountAndAverageScoreByRecipeId(recipe.getId());
+						Long totalPrice = recipeRepository.getTotalPrice(recipe.getId());
+						double averageScore = stats != null && stats.getAverageScore() != null ? stats.getAverageScore() : 0.0;
+						int commentCount = stats != null && stats.getReviewCount() != null ? stats.getReviewCount().intValue() : 0;
+						return RecipeResponse.toDTO(recipe, averageScore, commentCount, totalPrice);
+					})
+					.toList()
+				)
+				.build();
+		} catch (IllegalArgumentException e) {
+			log.error("잘못된 검색어가 입력되었습니다: {}", keyword, e);
+			throw e;
+		} catch (Exception e) {
+			log.error("레시피 검색 중 오류가 발생했습니다. 검색어: {}", keyword, e);
+			throw e;
+		}
 	}
 }

--- a/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
@@ -1,7 +1,7 @@
 package com.costcook.service.impl;
 
 import java.util.List;
-
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,11 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class RecipeServiceImpl implements RecipeService {
-	
 	private final RecipeRepository recipeRepository;
-	private RecipeIngredientRepository recipeIngredientRepository;
+	private final RecipeIngredientRepository recipeIngredientRepository;
 
-	
 	// 레시피 목록 조회
 	@Override
 	public RecipeListResponse getRecipes(int page, int size, String sort, String order) {
@@ -54,10 +52,7 @@ public class RecipeServiceImpl implements RecipeService {
         	} else {
         		recipePage = recipeRepository.findAllByOrderByCreatedAtDesc(pageable);        		
         	}
-        	
         }
-//        log.info("element:{}", recipePage.getTotalElements());
-     
         
 		// 응답할 데이터 
         return RecipeListResponse.builder()
@@ -78,6 +73,7 @@ public class RecipeServiceImpl implements RecipeService {
     				.toList())
         	.build();
 	}
+	
 	
 	// 전체 레시피 수 조회 : 총 페이지를 미리 입력하여, 무한 로딩 방지
 	@Override
@@ -107,8 +103,4 @@ public class RecipeServiceImpl implements RecipeService {
 		// 리뷰 개수 가져오기
 		return RecipeResponse.toDTO(recipe, averageScore, commentCount, totalPrice);
 	}
-	
-	
-	
-	
 }

--- a/costcook/src/main/java/com/costcook/service/impl/ReviewServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/ReviewServiceImpl.java
@@ -36,16 +36,14 @@ public class ReviewServiceImpl implements ReviewService {
 	private final RecipeRepository recipeRepository;
 	private final ReviewRepository reviewRepository;
 	
-	
 	// 레시피 상세페이지 > 리뷰 목록 가져오기
 	@Override
 	public ReviewListResponse getReviewList(Long recipeId, int page, int size) {
 		int validPage = Math.max(page, 1) - 1; // 최소 페이지 설정: 1부터
 		Pageable pageable = PageRequest.of(validPage, size);
-//		생성일 기준으로 정렬된 리뷰 목록을 가져옴
+		// 생성일 기준으로 정렬된 리뷰 목록을 가져옴
+		// FIX: deleted_at 필드가 null 이 아닌 즉 삭제되지 않은 리뷰 목록만 조회 필요.
 		Page<Review> reviewPage = reviewRepository.findByRecipeIdOrderByCreatedAtDesc(recipeId, pageable);
-
-//		log.info("리뷰정보: {}", reviewPage.getContent());
 		
 		// 응답할 데이터
 		return ReviewListResponse.builder()
@@ -57,9 +55,7 @@ public class ReviewServiceImpl implements ReviewService {
 				reviewPage.getContent().stream().map(ReviewResponse::toDTO).toList()		
 			)
 			.build();
-		
 	}
-
 	
 	// 리뷰 등록
 	@Override
@@ -78,15 +74,6 @@ public class ReviewServiceImpl implements ReviewService {
 		Review result = reviewRepository.save(review);
 		return CreateReviewResponse.toDTO(result);
 	}
-
-	@Override
-	public List<ReviewResponse> getReviewList(Long recipeId) {
-		List<Review> reviewList = reviewRepository.findAllByRecipeId(recipeId);
-		return reviewList.stream()
-	        .filter(review -> review.getDeletedAt() == null) // 삭제되지 않은 리뷰만 필터링
-	        .map(ReviewResponse::toDTO)
-	        .toList();
-		}
 	
 	// 삭제
 	@Transactional


### PR DESCRIPTION
## 작업 내용 (What)
레시피 검색 API 구현

## 작업 이유 (Why)
새로운 기능 추가

## 변경 사항 (Changes)
- [ ] API 엔드포인트 추가
- [ ] `page`파라미터로 원하는 페이지를 요청할 수 있도록 구현
- [ ] `keyword`에 대한 예외 처리. 특히 빈 값, null 값, 불필요한 공백만 있는 경우 등에 대해 예외 처리 > 400 Bad Request
- [ ] 레시피 검색 로직 구현(검색 대상: 레시피 이름 및 레시피 구성 재료명)

## 테스트 결과 (Test Result)
keyword paramteter 가 누락된 겨우,
![image](https://github.com/user-attachments/assets/3afd727c-6bda-4141-9291-63854ed7ec64)

정상적인 검색,
![image](https://github.com/user-attachments/assets/a699e082-1ffa-4812-af19-3978add37649)

검색했는데, 검색된 레시피가 없을 때,
![image](https://github.com/user-attachments/assets/3726096b-32a5-401d-bb14-0e6b391dad2d)

