### PR TITLE
feat:즐겨찾기 테이블,Response 추가

### DIFF
--- a/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
+++ b/costcook/src/main/java/com/costcook/config/WebSecurityConfig.java
@@ -72,6 +72,10 @@ public class WebSecurityConfig {
 				new AntPathRequestMatcher("/api/auth/**"),
 				new AntPathRequestMatcher("/api/auth/token/refresh"),
 				new AntPathRequestMatcher("/api/recipes/**"),// 사용자 레시피 조회
+				
+				new AntPathRequestMatcher("/**"), // (임시)
+				
+
 				// 임시 admin 
 				new AntPathRequestMatcher("/api/admin/ingredients/**"),
 				new AntPathRequestMatcher("/api/admin/recipes/**") 

--- a/costcook/src/main/java/com/costcook/controller/FavoriteController.java
+++ b/costcook/src/main/java/com/costcook/controller/FavoriteController.java
@@ -1,0 +1,42 @@
+package com.costcook.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.costcook.domain.response.FavoriteListResponse;
+import com.costcook.domain.response.FavoriteResponse;
+import com.costcook.service.FavoriteService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/favories")
+public class FavoriteController {
+
+	private final FavoriteService favoriteService;
+	
+	// 즐겨찾기 조회
+	@GetMapping(value = {"", "/"})
+	public ResponseEntity<FavoriteListResponse> getAllFavorite(@RequestParam Long userId) {
+		// 즐겨찾기 목록 가져오기
+		FavoriteListResponse response = favoriteService.getFavoritesByUserId(userId);
+		return ResponseEntity.ok(response);
+	}
+	
+	
+	// 즐겨찾기 추가(등록)
+	
+	
+	
+	// 즐겨찾기 삭제(취소)
+	
+	
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/controller/ReviewController.java
+++ b/costcook/src/main/java/com/costcook/controller/ReviewController.java
@@ -30,8 +30,10 @@ public class ReviewController {
 	
 	// 리뷰 작성
 	@PostMapping("")
-	public ResponseEntity<CreateReviewResponse> createReview(@RequestBody CreateReviewRequest reviewRequest, @AuthenticationPrincipal User user) {
-		CreateReviewResponse result = reviewService.createReview(reviewRequest, user);
+//	public ResponseEntity<CreateReviewResponse> createReview(@RequestBody CreateReviewRequest reviewRequest, @AuthenticationPrincipal User user) {
+	public ResponseEntity<CreateReviewResponse> createReview(@RequestBody CreateReviewRequest reviewRequest) {
+//		CreateReviewResponse result = reviewService.createReview(reviewRequest, user);
+		CreateReviewResponse result = reviewService.createReview(reviewRequest);
 		if (result.getReviewId() == null) 
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(result);
 		return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/costcook/src/main/java/com/costcook/domain/response/FavoriteListResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/FavoriteListResponse.java
@@ -1,0 +1,16 @@
+package com.costcook.domain.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class FavoriteListResponse {
+
+	private List<FavoriteResponse> favorites;
+	
+}

--- a/costcook/src/main/java/com/costcook/domain/response/FavoriteResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/FavoriteResponse.java
@@ -1,0 +1,27 @@
+package com.costcook.domain.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FavoriteResponse {
+
+	private Long recipeId;
+	private String recipeTitle;
+	private String recipeThumbNail;
+	private Double recipeAvgRatings;
+	private int recipePrice;
+	
+	// favorite -> response 변환
+	public static FavoriteResponse toDTO(RecipeResponse recipeResponse) {
+		return FavoriteResponse.builder()
+				.recipeId(recipeResponse.getId())
+				.recipeTitle(recipeResponse.getTitle())
+				.recipeThumbNail(recipeResponse.getThumbnailUrl())
+				.recipeAvgRatings(recipeResponse.getAvgRatings())
+				.recipePrice(recipeResponse.getPrice())
+				.build();
+	}
+	
+}

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeDetailResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeDetailResponse.java
@@ -13,6 +13,7 @@ public class RecipeDetailResponse {
     private String title;
     private String description;
     private String thumbnailUrl;
+    private int rcpSno;
     private int servings;
     private int viewCount;
     private int favoriteCount;
@@ -27,6 +28,7 @@ public class RecipeDetailResponse {
     		.title(recipeResponse.getTitle())
     		.description(recipeResponse.getDescription())
     		.thumbnailUrl(recipeResponse.getThumbnailUrl())
+    		.rcpSno(recipeResponse.getRcpSno())
     		.servings(recipeResponse.getServings())
     		.viewCount(recipeResponse.getViewCount())
     		.price(recipeResponse.getPrice())

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeResponse.java
@@ -17,7 +17,7 @@ public class RecipeResponse {
 	private String title, description, thumbnailUrl, createdAt, updatedAt;
 	private int servings, price, viewCount, favoriteCount, reviewCount;
 	private double avgRatings;
-  private Category category;
+	private Category category;
 
 	// Recipe -> response 변환
 	// 전체 목록

--- a/costcook/src/main/java/com/costcook/entity/Favorite.java
+++ b/costcook/src/main/java/com/costcook/entity/Favorite.java
@@ -1,0 +1,76 @@
+package com.costcook.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "favorites")
+public class Favorite {
+	
+	// id(복합키), 회원 식별자, 레시피 식별자, 등록일, 삭제일
+
+	// 복합키
+	@EmbeddedId
+	private FavoriteId id;
+	
+	// 회원 식별자
+	@ManyToOne
+	@MapsId("userId")
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	// 레시피 식별자
+	@ManyToOne
+	@MapsId("recipeId")
+	@JoinColumn(name = "recipe_id", nullable = false)
+	private Recipe recipe;
+	
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+	
+	// 삭제일 : 즐겨찾기 ON, OFF
+	@LastModifiedDate
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+	
+	@PrePersist
+	public void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+	
+	// Soft delete 메소드 : 즐겨찾기가 생성 -> 삭제 -> 생성시 새 데이터가 생기는게 아니라 update
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+	
+	
+	
+	
+	
+	
+
+}

--- a/costcook/src/main/java/com/costcook/entity/FavoriteId.java
+++ b/costcook/src/main/java/com/costcook/entity/FavoriteId.java
@@ -1,0 +1,37 @@
+package com.costcook.entity;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 즐겨찾기 테이블의 복합키
+
+@Embeddable
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FavoriteId implements Serializable {
+
+	private Long userId;
+	private Long recipeId;
+	
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof FavoriteId)) return false;
+		FavoriteId that = (FavoriteId) o;
+		return Objects.equals(userId, that.userId) &&
+			   Objects.equals(recipeId, that.recipeId);
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(userId, recipeId);
+	}
+	
+	
+}

--- a/costcook/src/main/java/com/costcook/repository/FavoriteRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/FavoriteRepository.java
@@ -1,0 +1,16 @@
+package com.costcook.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.costcook.domain.response.FavoriteResponse;
+import com.costcook.entity.Favorite;
+
+@Repository
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+	List<Favorite> findByUserId(Long userId);
+
+}

--- a/costcook/src/main/java/com/costcook/service/FavoriteService.java
+++ b/costcook/src/main/java/com/costcook/service/FavoriteService.java
@@ -1,0 +1,13 @@
+package com.costcook.service;
+
+import com.costcook.domain.response.FavoriteListResponse;
+
+public interface FavoriteService {
+
+
+	// 유저ID에 맞는 즐겨찾기 목록 가져오기
+	FavoriteListResponse getFavoritesByUserId(Long userId);
+
+
+
+}

--- a/costcook/src/main/java/com/costcook/service/ReviewService.java
+++ b/costcook/src/main/java/com/costcook/service/ReviewService.java
@@ -1,7 +1,5 @@
 package com.costcook.service;
 
-import java.util.List;
-
 import com.costcook.domain.request.CreateReviewRequest;
 import com.costcook.domain.request.UpdateReviewRequest;
 import com.costcook.domain.response.CreateReviewResponse;
@@ -11,14 +9,25 @@ import com.costcook.entity.User;
 
 public interface ReviewService {
 
-	CreateReviewResponse createReview(CreateReviewRequest reviewRequest, User user);
-
+//	// 리뷰 작성
+//	CreateReviewResponse createReview(CreateReviewRequest reviewRequest, User user);
+	
+	////////////
+	// 리뷰 작성 TEST
+	CreateReviewResponse createReview(CreateReviewRequest reviewRequest);
+////////////////
+	
+	
+	// 리뷰 삭제
 	boolean deleteReview(User user, Long reviewId);
 
+	// 리뷰 수정
 	ReviewResponse modifyReview(UpdateReviewRequest updateReviewRequest, User user, Long reviewId);
 
+	// 리뷰 목록 가져오기(모든 사용자)
 	ReviewListResponse getReviewList(Long recipeId, int page, int size);
 
+	// 리뷰 목록 가져오기(마이페이지)
 	ReviewListResponse getReviewListByUserWithPagination(User user, int page);
 
 }

--- a/costcook/src/main/java/com/costcook/service/impl/FavoriteServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/FavoriteServiceImpl.java
@@ -1,0 +1,33 @@
+package com.costcook.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.costcook.domain.response.FavoriteListResponse;
+import com.costcook.repository.FavoriteRepository;
+import com.costcook.service.FavoriteService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FavoriteServiceImpl implements FavoriteService {
+
+	private final FavoriteRepository favoriteRepository;
+	
+	// 유저ID로 유저가 작성한 즐겨찾기 목록 가져오기
+    public FavoriteListResponse getFavoritesByUserId(Long userId) {
+    	
+    	log.info("즐겨찾기 목록 가져오기{}: " );
+		return null;
+
+    	
+    }
+
+
+	
+	
+	
+
+}

--- a/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/RecipeServiceImpl.java
@@ -98,7 +98,6 @@ public class RecipeServiceImpl implements RecipeService {
 		Long totalPrice = recipeRepository.getTotalPrice(recipe.getId());
 		// 레시피 테이블에 가격 반영
 		recipe.setPrice(totalPrice.intValue());
-		
 		// 리뷰 개수 가져오기
 		return RecipeResponse.toDTO(recipe, averageScore, commentCount, totalPrice);
 	}

--- a/costcook/src/main/java/com/costcook/service/impl/ReviewServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/ReviewServiceImpl.java
@@ -59,13 +59,17 @@ public class ReviewServiceImpl implements ReviewService {
 	
 	// 리뷰 등록
 	@Override
-	public CreateReviewResponse createReview(CreateReviewRequest reviewRequest, User user) {
+//	public CreateReviewResponse createReview(CreateReviewRequest reviewRequest, User user) {
+	
+	// 리뷰 등록 TEST(로그인 상태라 가정)
+	
+	public CreateReviewResponse createReview(CreateReviewRequest reviewRequest) {
 		Optional<Recipe> optRecipe = recipeRepository.findById(reviewRequest.getRecipeId());
 		if (optRecipe.isEmpty()) {
 			throw new NotFoundException("해당 레시피를 찾을 수 없습니다.");
 		}
 		Review review = Review.builder()
-			.user(user)
+//			.user(user)
 			.recipe(optRecipe.get())
 			.score(reviewRequest.getScore())
 			.comment(reviewRequest.getComment())
@@ -74,6 +78,11 @@ public class ReviewServiceImpl implements ReviewService {
 		Review result = reviewRepository.save(review);
 		return CreateReviewResponse.toDTO(result);
 	}
+	
+	
+	
+	
+	
 	
 	// 삭제
 	@Transactional


### PR DESCRIPTION
## 작업 내용 (What)
즐겨찾기(Favorite) 테이블 생성

## 작업 이유 (Why)
사용자가 레시피를 즐겨찾기해서, 내 즐겨찾기 목록에서 즐겨찾기한 레시피 목록만 조회가능

## 변경 사항 (Changes)
- 즐겨찾기(Favorite) 테이블 생성 =>  UserId와 RecipeId를 연결한 "FavoriteId"를 복합키로 사용하는 테이블 생성
- 즐겨찾기DTO(FavoriteResponse) 생성 => 레시피의 정보를 가지고 있는 DTO

## 테스트 결과 (Test Result)
![createFavorite](https://github.com/user-attachments/assets/13430ffa-3a9a-4f4e-8756-90353a91684a)

