### PR TITLE
Feat: 레시피 목록 조회 API 파라미터로 ids 추가 및 그에 따른 로직 구현

### DIFF
--- a/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
+++ b/costcook/src/main/java/com/costcook/controller/CommonRecipeController.java
@@ -41,17 +41,27 @@ public class CommonRecipeController {
 	
 	// 레시피 전체 목록 조회 
 	@GetMapping(value = {"", "/"})
-	public ResponseEntity<RecipeListResponse> getAllRecipe(
+	public ResponseEntity<?> getAllRecipe(
 		@RequestParam(name = "page", defaultValue = "1") int page, 
 		@RequestParam(name = "size", defaultValue = "9") int size, 
 		@RequestParam(name = "sort", defaultValue = "createdAt") String sort,
 		@RequestParam(name = "order", defaultValue = "desc") String order,
-		@AuthenticationPrincipal User user
+		@AuthenticationPrincipal User user,
+		@RequestParam(required = false, name = "ids") List<Long> ids // 여러 개의 레시피 id 를 요청으로 받음.
 	) {
+		if (ids != null && !ids.isEmpty()) {
+			// 특정 IDs가 존재하는 경우 해당 레시피 목록만 가져오기
+			List<RecipeResponse> recipes = recipeService.getRecipesByIds(ids, user);
+			return ResponseEntity.ok(recipes);
+		} else {
+			// IDs가 없을 경우 전체 레시피 목록 가져오기
+			RecipeListResponse response = recipeService.getRecipes(page, size, sort, order, user);
+			return ResponseEntity.ok(response);
+		}
 		// 레시피 목록 가져오기
-		RecipeListResponse response = recipeService.getRecipes(page, size, sort, order, user);
+		// RecipeListResponse response = recipeService.getRecipes(page, size, sort, order, user);
 
-		return ResponseEntity.ok(response);
+		// return ResponseEntity.ok(response);
 	}
 
 	// 레시피 검색

--- a/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeListResponse.java
@@ -18,4 +18,3 @@ public class RecipeListResponse {
     private Long totalRecipes; // 전체 레시피 수
     private List<RecipeResponse> recipes; // 레시피 목록
 }
-

--- a/costcook/src/main/java/com/costcook/service/RecipeService.java
+++ b/costcook/src/main/java/com/costcook/service/RecipeService.java
@@ -12,6 +12,9 @@ public interface RecipeService {
 
 	// 레시피 목록 가져오기
 	RecipeListResponse getRecipes(int page, int size, String sort, String order, User user);
+
+	// 특정 IDs 목록에 해당하는 레시피들 가져오기
+	List<RecipeResponse> getRecipesByIds(List<Long> ids, User user);
 	
 	// 레시피 총 개수
 	long getTotalRecipes();


### PR DESCRIPTION
## 작업 내용 (What)
레시피 목록 조회 API 파라미터로 ids 추가 및 그에 따른 로직 구현

## 작업 이유 (Why)
비회원이 즐겨찾기에 추가된 id 를 바탕으로 레시피 목록 조회 시 필요.

## 변경 사항 (Changes)
코드 변경 사항에 대해 구체적으로 설명합니다.

- [ ] 레시피 목록 조회 API 파라미터로 ids 추가 및 그에 따른 로직 구현
