### PR TITLE
Fix: 내 리뷰 목록 조회 API 및 레시피 상세정보 조회 API 변경

### DIFF
--- a/costcook/src/main/java/com/costcook/domain/response/RecipeDetailResponse.java
+++ b/costcook/src/main/java/com/costcook/domain/response/RecipeDetailResponse.java
@@ -15,12 +15,11 @@ public class RecipeDetailResponse {
     private String thumbnailUrl;
     private int rcpSno;
     private int servings;
-    private int viewCount;
-    private int favoriteCount;
     private int reviewCount;
     private int price;
     private double avgRatings;
     private List<IngredientResponse> ingredients;
+	private boolean isFavorite;
 	
     public static RecipeDetailResponse toDTO(RecipeResponse recipeResponse, List<IngredientResponse> ingredients) {
     	return RecipeDetailResponse.builder()
@@ -30,12 +29,11 @@ public class RecipeDetailResponse {
     		.thumbnailUrl(recipeResponse.getThumbnailUrl())
     		.rcpSno(recipeResponse.getRcpSno())
     		.servings(recipeResponse.getServings())
-    		.viewCount(recipeResponse.getViewCount())
     		.price(recipeResponse.getPrice())
-    		// .favoriteCount(recipeResponse.getFavoriteCount())
     		.reviewCount(recipeResponse.getReviewCount())
     		.avgRatings(recipeResponse.getAvgRatings())
     		.ingredients(ingredients)
+			.isFavorite(recipeResponse.isFavorite())
     		.build();
 	}
 }

--- a/costcook/src/main/java/com/costcook/repository/ReviewRepository.java
+++ b/costcook/src/main/java/com/costcook/repository/ReviewRepository.java
@@ -33,5 +33,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>{
     @Query("SELECT r FROM Review r WHERE r.user.id = :userId AND r.deletedAt IS NULL AND r.status = false")
     Page<Review> findAllByUserIdAndStatusFalseAndNotDeleted(@Param("userId") Long userId, Pageable pageable);
 
-    Optional<Review> findByUserAndRecipe(User user, Recipe recipe);
+    @Query("SELECT r FROM Review r WHERE r.user = :user AND r.recipe = :recipe AND r.deletedAt IS NULL AND r.status = false")
+    Optional<Review> findByUserAndRecipe(@Param("user") User user, @Param("recipe") Recipe recipe);
 }


### PR DESCRIPTION
## 작업 내용 (What)
내 리뷰 목록 조회 시 deleted_at 이 null 이고 status 가 false 인 리뷰만 조회하도록 변경.
레시피 상세정보 조회 API 응답 데이터로 favorite 필드 추가.

## 작업 이유 (Why)
로직 개선 및 필요한 데이터 추가

## 변경 사항 (Changes)
코드 변경 사항에 대해 구체적으로 설명합니다.

- [x] 내 리뷰 목록 조회 시 deleted_at 이 null 이고 status 가 false 인 리뷰만 조회하도록 변경.
- [x] 레시피 상세정보 조회 API 응답 데이터로 favorite 필드 추가.
