### PR TITLE
Fix: 로그인 API 에서 예산 및 즐겨찾기 저장 로직 제거

### DIFF
--- a/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
+++ b/costcook/src/main/java/com/costcook/domain/request/SignUpOrLoginRequest.java
@@ -22,11 +22,5 @@ public class SignUpOrLoginRequest {
 
     // (비회원) 즐겨찾기 추가된 레시피 ID 목록
     private List<Long> favoriteRecipeIds;
-
-    // (비회원) 설정한 예산 정보
-    private WeeklyBudgetRequest budget;
-
-    // (비회원) 추가한 레시피 목록
-    private List<RecommendedRecipeRequest> recommendedRecipes;
 }
 

--- a/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
+++ b/costcook/src/main/java/com/costcook/service/impl/AuthServiceImpl.java
@@ -106,16 +106,6 @@ public class AuthServiceImpl implements AuthService {
                 // FavoriteServiceImpl의 createFavorites 메소드 호출
                 favoriteService.createFavorites(user, favoriteRequest);
             }
-
-            // 3-2. 비회원이 저장한 예산 추가 로직
-            if (request.getBudget() != null) {
-                weeklyBudgetService.settingWeeklyBudget(request.getBudget(), user);
-            }
-
-            // 3-3. 비회원이 저장한 추천 레시피 추가 로직
-            if (request.getRecommendedRecipes() != null && !request.getRecommendedRecipes().isEmpty()) {
-                recipeService.addRecommendedRecipes(request.getRecommendedRecipes(), user);
-            }
     
             // 4. 액세스 토큰, 리프레시 토큰 발급
             Map<String, String> tokenMap = tokenUtils.generateToken(user);


### PR DESCRIPTION
## 작업 내용 (What)
로그인 API 에서 예산 및 즐겨찾기 저장 로직 제거

## 작업 이유 (Why)
비회원에서 회원으로 전환하면서 비회원이 설정한 예산 및 추천받은 레시피는 무시.

## 변경 사항 (Changes)
- [ ] 로그인 API 에서 예산 및 즐겨찾기 저장 로직 제거
